### PR TITLE
Added prefix stanza to the antibody schema yaml

### DIFF
--- a/model/schema/antibody.yaml
+++ b/model/schema/antibody.yaml
@@ -5,6 +5,15 @@ imports:
   - reference
   - linkml:types
 
+prefixes:
+  alliance: 'http://alliancegenome.org'
+  linkml: 'https://w3id.org/linkml/'
+  gff: 'https://w3id.org/gff'
+  faldo: 'http://biohackathon.org/resource/faldo#'
+  biolink: 'https://w3id.org/biolink/vocab/'
+  NLMID: 'https://www.ncbi.nlm.nih.gov/nlmcatalog/?term='
+  schema: 'http://schema.org/'
+
 classes:
 
   Antibody:


### PR DESCRIPTION
Possibly a quirk of the OO-generator code, but I ran into errors because prefixes were left out on just this file. 