### PR TITLE
Fixing 'reference' slot 'Reference' class naming clash on Macs

### DIFF
--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -496,8 +496,13 @@ slots:
     multivalued: true
     range: Reference
 
-  reference:
-    description: holds between an object and a single reference
+  annotation_reference:
+    description: holds between an annotation and a single reference
+    multivalued: false
+    range: Reference
+
+  entity_reference:
+    description: holds between an entity and a single reference
     multivalued: false
     range: Reference
 

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -75,7 +75,7 @@ classes:
           statement of the phenotype from a post-composed terminology
         required: true
         range: string
-      reference:
+      annotation_reference:
         description: >-
           The reference in which the phenotype association was asserted/reported.
       creation_date:
@@ -165,7 +165,7 @@ classes:
       - mod_id
       - negated
       - evidence_codes
-      - reference
+      - annotation_reference
       - annotation_type
       - with
       - disease_qualifiers
@@ -212,7 +212,7 @@ classes:
           indicated disease based on sequence-similarity/sequence-orthology "with" some human
           gene. Currently used by SGD.
         required: false    # Required for SGD disease annotations using ISS or ISO evidence codes
-      reference:               # evidence in JSON schema
+      annotation_reference:               # evidence in JSON schema
         required: true
         description: >-
           The reference in which the disease association was asserted/reported.
@@ -401,10 +401,10 @@ classes:
       conditions from ZFIN to label (in a reference-specific manner) individual
       experimental conditions when curating a particular reference.
     slots:
-      - reference
+      - entity_reference
       - handle
     slot_usage:
-      reference:
+      entity_reference:
         required: true
       handle:
         required: true


### PR DESCRIPTION
Macs have a problem with LinkML entities (e.g. classes or slots) have the same name except for case. We recently have added a 'reference' slot in addition to the existing 'Refefence' class which causes a naming conflict on Mac computers. I have changed the 'reference' slot back to 'annotation_reference' and added an 'entity_reference' slot to be used by the PaperHandle class and any other non-association/non-annotation entity going forward.