### PR TITLE
Add "related_notes" slot to "Antibody" class and delete the "AntibodyStatement" class.

### DIFF
--- a/model/schema/antibody.yaml
+++ b/model/schema/antibody.yaml
@@ -45,6 +45,7 @@ classes:
       - secondary_identifiers
       - references
       - original_reference
+      - related_notes
       # - disease    # Need a way to give DOID term and reference. Or a generic way to specify CV term and publication attribution.
     slot_usage:
       curie:
@@ -75,11 +76,6 @@ classes:
           The reference providing the original description of the antibody's
           generation.
 
-  AntibodyNote:
-    is_a: EntityStatement
-    slot_usage:
-      note_type:
-        range: antibody_note_type_set
 
 slots:
 


### PR DESCRIPTION
These suggested changes were necessitated by the implementation of the new "Note" class, which is intended to replace the "EntityStatement" class.

Even though they are no longer referenced by anything, I left the `antibody_note_type_set` enum there for future reference. I suspect these will need to become ControlledVocabularyTerm objects so that the proper Note types can be created.