### PR TITLE
Remove 'inferred_gene' entry

### DIFF
--- a/test/data/fb_disease_test.json
+++ b/test/data/fb_disease_test.json
@@ -8,7 +8,6 @@
       "evidence_codes": ["ECO:0007013"],
       "single_reference": "FB:FBrf0227496",
       "annotation_type": "manually_curated",
-      "inferred_gene": "FB:FBgn0000047",
       "data_provider": "FB",
       "created_by": "FB:FB_curator",
       "creation_date": "2022-01-12T09:57:42-05:00",


### PR DESCRIPTION
@gildossantos  I'm going to suggest removing the 'inferred_gene' entry as that is intended to be only derived automatically (by yet-to-be-instantiated "roll-up" rules) and not submitted.