### PR TITLE
Proposal for dealing with allele (and other) evidence

### DIFF
--- a/jsonschema/allianceModel.schema.json
+++ b/jsonschema/allianceModel.schema.json
@@ -451,8 +451,8 @@
                "type": "string"
             },
             "database_status": {
-               "description": "Database status of the allele",
-               "type": "string"
+               "$ref": "#/$defs/DatabaseStatus",
+               "description": "Database status of the allele and associated evidence"
             },
             "date_created": {
                "description": "The date on which an entity was created. This can be applied to nodes or edges.",
@@ -471,13 +471,17 @@
                },
                "type": "array"
             },
+            "evidence": {
+               "$ref": "#/$defs/Evidence",
+               "description": "evidence associated with a property"
+            },
             "functional_impact": {
-               "description": "Experimentally assessed functional impact of the allele, e.g. knockout / amorphic",
-               "type": "string"
+               "$ref": "#/$defs/FunctionalImpact",
+               "description": "Experimentally assessed functional impact of the allele and associated evidence"
             },
             "generation_method": {
-               "description": "Technique used to create the allele, e.g. spontaneous / naturally occuring / radiation",
-               "type": "string"
+               "$ref": "#/$defs/GenerationMethod",
+               "description": "Technique used to create the allele and associated evidence"
             },
             "genomic_locations": {
                "items": {
@@ -536,9 +540,9 @@
                "type": "boolean"
             },
             "origins": {
-               "description": "Affected genomic models that the allele was introduced in",
+               "description": "Affected genomic models that the allele was introduced in and associated evidence",
                "items": {
-                  "type": "string"
+                  "$ref": "#/$defs/Origin"
                },
                "type": "array"
             },
@@ -550,6 +554,13 @@
                "description": "Holds between an object and a list of related Note objects.",
                "items": {
                   "$ref": "#/$defs/Note"
+               },
+               "type": "array"
+            },
+            "rflp_experiments": {
+               "description": "RFLP experiments used to identify allele",
+               "items": {
+                  "$ref": "#/$defs/RFLPExperiment"
                },
                "type": "array"
             },
@@ -1050,6 +1061,43 @@
             "object"
          ],
          "title": "AlleleVariantAssociation",
+         "type": "object"
+      },
+      "Analysis": {
+         "additionalProperties": false,
+         "description": "Dummy analysis class",
+         "properties": {
+            "created_by": {
+               "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "modified_by": {
+               "description": "The individual that last modified the entity.",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "Analysis",
          "type": "object"
       },
       "AnatomicalSite": {
@@ -2401,6 +2449,52 @@
          "title": "DOTerm",
          "type": "object"
       },
+      "DatabaseStatus": {
+         "additionalProperties": false,
+         "description": "Database status of the allele and associated evidence",
+         "properties": {
+            "created_by": {
+               "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "database_status_term": {
+               "description": "Database status of the allele",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence": {
+               "$ref": "#/$defs/Evidence",
+               "description": "evidence associated with a property"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "modified_by": {
+               "description": "The individual that last modified the entity.",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            }
+         },
+         "required": [
+            "internal",
+            "database_status_term"
+         ],
+         "title": "DatabaseStatus",
+         "type": "object"
+      },
       "DetectionMethodsEnum": {
          "description": "",
          "enum": [
@@ -2912,6 +3006,75 @@
          ],
          "title": "EntitySynonymTypeSet",
          "type": "string"
+      },
+      "Evidence": {
+         "additionalProperties": false,
+         "description": "Evidence associated with a class Property",
+         "properties": {
+            "authors": {
+               "description": "Ordered author entities for this publication.  An Author is associated with only one publication.  A Person can be associated with multiple  publications.",
+               "items": {
+                  "$ref": "#/$defs/AuthorReference"
+               },
+               "type": "array"
+            },
+            "created_by": {
+               "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "curator_confirmed": {
+               "description": "Confirmation of the annotation/association by a curator",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "modified_by": {
+               "description": "The individual that last modified the entity.",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "persons": {
+               "description": "A collection of people, not necessarily related in any way",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "references": {
+               "description": "holds between an object and a list of references",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "related_notes": {
+               "description": "Holds between an object and a list of related Note objects.",
+               "items": {
+                  "$ref": "#/$defs/Note"
+               },
+               "type": "array"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "Evidence",
+         "type": "object"
       },
       "ExperimentalCondition": {
          "additionalProperties": false,
@@ -3701,6 +3864,52 @@
          "title": "File",
          "type": "object"
       },
+      "FunctionalImpact": {
+         "additionalProperties": false,
+         "description": "Functional impact of allele and related evidence",
+         "properties": {
+            "created_by": {
+               "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence": {
+               "$ref": "#/$defs/Evidence",
+               "description": "evidence associated with a property"
+            },
+            "functional_impact_description": {
+               "description": "Experimentally assessed functional impact of the allele, e.g. knockout / amorphic",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "modified_by": {
+               "description": "The individual that last modified the entity.",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            }
+         },
+         "required": [
+            "internal",
+            "functional_impact_description"
+         ],
+         "title": "FunctionalImpact",
+         "type": "object"
+      },
       "GOTerm": {
          "additionalProperties": false,
          "description": "",
@@ -4369,6 +4578,52 @@
             "subject"
          ],
          "title": "GenePhenotypeAnnotation",
+         "type": "object"
+      },
+      "GenerationMethod": {
+         "additionalProperties": false,
+         "description": "Generation method of allele and related evidence",
+         "properties": {
+            "created_by": {
+               "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence": {
+               "$ref": "#/$defs/Evidence",
+               "description": "evidence associated with a property"
+            },
+            "generation_method_description": {
+               "description": "Technique used to create the allele, e.g. spontaneous / naturally occuring / radiation",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "modified_by": {
+               "description": "The individual that last modified the entity.",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            }
+         },
+         "required": [
+            "internal",
+            "generation_method_description"
+         ],
+         "title": "GenerationMethod",
          "type": "object"
       },
       "GenomicEntity": {
@@ -5720,6 +5975,10 @@
                "format": "date",
                "type": "string"
             },
+            "evidence": {
+               "$ref": "#/$defs/Evidence",
+               "description": "evidence associated with a property"
+            },
             "free_text": {
                "description": "A free text string that describes some aspect of an entity.",
                "type": "string"
@@ -5739,13 +5998,6 @@
             "obsolete": {
                "description": "Entity is no longer current.",
                "type": "boolean"
-            },
-            "references": {
-               "description": "holds between an object and a list of references",
-               "items": {
-                  "type": "string"
-               },
-               "type": "array"
             }
          },
          "required": [
@@ -5884,6 +6136,59 @@
             "internal"
          ],
          "title": "Organization",
+         "type": "object"
+      },
+      "Origin": {
+         "additionalProperties": false,
+         "description": "Affected genomic models that the allele was introduced in and associated evidence",
+         "properties": {
+            "analyses": {
+               "description": "Analyses providing evidence for AGM of origin",
+               "items": {
+                  "$ref": "#/$defs/Analysis"
+               },
+               "type": "array"
+            },
+            "created_by": {
+               "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence": {
+               "$ref": "#/$defs/Evidence",
+               "description": "evidence associated with a property"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "modified_by": {
+               "description": "The individual that last modified the entity.",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "origin": {
+               "description": "Affected genomic models that the allele was introduced in",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "origin"
+         ],
+         "title": "Origin",
          "type": "object"
       },
       "Person": {
@@ -6308,6 +6613,40 @@
          ],
          "title": "PubmedTypeEnum",
          "type": "string"
+      },
+      "RFLPExperiment": {
+         "additionalProperties": false,
+         "description": "Details of RFLP analysis results",
+         "properties": {
+            "polymorphic_strain_bands": {
+               "description": "Sizes of RFLP bands produced in RFLP experiment for polymorphic strain",
+               "items": {
+                  "type": "integer"
+               },
+               "type": "array"
+            },
+            "reference_strain_bands": {
+               "description": "Sizes of RFLP bands produced in RFLP experiment for reference strain",
+               "items": {
+                  "type": "integer"
+               },
+               "type": "array"
+            },
+            "restriction_enzymes": {
+               "description": "Restriction enzymes used in RFLP experiment",
+               "type": "string"
+            },
+            "restriction_site": {
+               "description": "RFLP experiment restriction site",
+               "type": "string"
+            }
+         },
+         "required": [
+            "restriction_site",
+            "restriction_enzymes"
+         ],
+         "title": "RFLPExperiment",
+         "type": "object"
       },
       "RNAClone": {
          "additionalProperties": false,
@@ -7134,6 +7473,10 @@
                "description": "Date on which an entity was last modified.",
                "format": "date",
                "type": "string"
+            },
+            "evidence": {
+               "$ref": "#/$defs/Evidence",
+               "description": "evidence associated with a property"
             },
             "internal": {
                "description": "Classifies the entity as private (for internal use) or not (for public use).",

--- a/model/schema/agent.yaml
+++ b/model/schema/agent.yaml
@@ -114,6 +114,6 @@ slots:
 
   persons:
     description: >-
-      A collection of people, not necessarily related in any
+      A collection of people, not necessarily related in any way
     multivalued: true
     range: Person

--- a/model/schema/agent.yaml
+++ b/model/schema/agent.yaml
@@ -111,3 +111,9 @@ slots:
     domain: LoggedInPerson
     range: string
     multivalued: false
+
+  persons:
+    description: >-
+      A collection of people, not necessarily related in any
+    multivalued: true
+    range: Person

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -10,6 +10,7 @@ imports:
   - linkml:types
   - ontologyTerm
   - affectedGenomicModel
+  - evidence
 
 prefixes:
   alliance: 'http://alliancegenome.org/'
@@ -140,6 +141,43 @@ classes:
       object:
         range: Variant
 
+  FunctionalImpact:
+    is_a: AuditedObject
+    description: >-
+      Functional impact of allele and related evidence
+    slots:
+      - functional_impact_description
+      - evidence
+
+  GenerationMethod:
+    is_a: AuditedObject
+    description:
+      Generation method of allele and related evidence
+    slots:
+      - generation_method_description
+      - evidence
+
+  Origin:
+    is_a: AuditedObject
+    description: >-
+      Affected genomic models that the allele was introduced in and associated
+      evidence
+    slots:
+      - origin
+      - evidence
+      - analyses
+    slot_usage:
+      analyses:
+        description: Analyses providing evidence for AGM of origin
+
+  DatabaseStatus:
+    is_a: AuditedObject
+    description: >-
+      Database status of the allele and associated evidence
+    slots:
+      - database_status_term
+      - evidence
+
   AssociatedReference:
     is_a: AuditedObject
     description: >-
@@ -166,6 +204,11 @@ classes:
     is_a: AuditedObject
     description: >-
       Dummy cell line class
+
+  Analysis:
+    is_a: AuditedObject
+    description: >-
+      Dummy analysis class
 
   SequenceTargetingReagent:
     description: >-
@@ -242,18 +285,34 @@ slots:
 
   functional_impact:
     description: >-
+      Experimentally assessed functional impact of the allele and associated
+      evidence
+    domain: Allele
+    range: FunctionalImpact
+
+  functional_impact_description:
+    description: >-
       Experimentally assessed functional impact of the
       allele, e.g. knockout / amorphic
-    domain: Allele
+    domain: FunctionalImpact
     range: string
+    multivalued: false
+    required: true
 
   generation_method:
     description: >-
+      Technique used to create the allele and associated evidence
+    domain: Allele
+    range: GenerationMethod
+
+  generation_method_description:
+    description: >-
       Technique used to create the allele, e.g.
       spontaneous / naturally occuring / radiation
-    domain: Allele
+    domain: GenerationMethod
     range: string
     multivalued: false
+    required: true
 
   associated_references:
     description: >-
@@ -272,12 +331,20 @@ slots:
     range: VocabularyTerm
 
   origins:
-    singular_name: origin
     description: >-
-      Affected genomic models that the allele was introduced in
+      Affected genomic models that the allele was introduced in and associated
+      evidence
     multivalued: true
     domain: Allele
+    range: Origin
+
+  origin:
+    description: >-
+      Affected genomic models that the allele was introduced in
+    domain: Origin
     range: AffectedGenomicModel
+    multivalued: false
+    required: true
 
   germline_transmission_status:
     description: >-
@@ -312,8 +379,14 @@ slots:
 
   database_status:
     description: >-
+      Database status of the allele and associated evidence
+    range: DatabaseStatus
+
+  database_status_term:
+    description: >-
       Database status of the allele
     range: VocabularyTerm
+    required: true
 
   inheritence_mode:
     description: >-
@@ -354,6 +427,11 @@ slots:
       by sequencing
     domain: Variant
     range: VocabularyTerm
+
+  analyses:
+    description: holds between an object and a list of references
+    multivalued: true
+    range: Analysis
 
 enums:
   construct_component_relation_enum:

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -69,6 +69,7 @@ classes:
       - aberration
       - is_extinct
       - sequencing_status
+      - rflp_experiments
     exact_mappings:
       - SO:0001023
     slot_usage:
@@ -250,10 +251,58 @@ classes:
     slots:
       - symbol
 
+  RFLPExperiment:
+    description: >-
+      Details of RFLP analysis results
+    slots:
+      - restriction_site
+      - restriction_enzymes
+      - reference_strain_bands
+      - polymorphic_strain_bands
+
 
 # Slots
 
 slots:
+
+  rflp_experiments:
+    description: >-
+      RFLP experiments used to identify allele
+    domain: Allele
+    range: RFLPExperiment
+    multivalued: true
+
+  restriction_site:
+    description: >-
+      RFLP experiment restriction site
+    domain: RFLPExperiment
+    range: biological_sequence
+    multivalued: false
+    required: true
+
+  restriction_enzymes:
+    description: >-
+      Restriction enzymes used in RFLP experiment
+    domain: RFLPExperiment
+    range: string
+    required: true
+    multivalued: false
+
+  reference_strain_bands:
+    description: >-
+      Sizes of RFLP bands produced in RFLP experiment for reference strain
+    domain: RFLPExperiment
+    range: integer
+    required: false
+    multivalued: true
+
+  polymorphic_strain_bands:
+    description: >-
+      Sizes of RFLP bands produced in RFLP experiment for polymorphic strain
+    domain: RFLPExperiment
+    range: integer
+    required: false
+    multivalued: true
 
   construct_components:
     multivalued: true

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -70,6 +70,7 @@ classes:
       - is_extinct
       - sequencing_status
       - rflp_experiments
+      - evidence # overlap with associated_references
     exact_mappings:
       - SO:0001023
     slot_usage:

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -134,7 +134,6 @@ classes:
     slots:
       - free_text
       - note_type
-      - references
       - evidence
     slot_usage:
       free_text:

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -24,6 +24,7 @@ imports:
   - image
   - ontologyTerm
   - controlledVocabulary
+  - evidence
 
 prefixes:
   alliance: 'http://alliancegenome.org/'
@@ -121,6 +122,7 @@ classes:
     is_a: AuditedObject
     slots:
       - synonym
+      - evidence
 
   Note:
     is_a: AuditedObject
@@ -133,6 +135,7 @@ classes:
       - free_text
       - note_type
       - references
+      - evidence
     slot_usage:
       free_text:
         required: true
@@ -247,6 +250,11 @@ slots:
 
   synonym:
     description: the text string of the synonym
+
+  evidence:
+    description: evidence associated with a property
+    range: Evidence
+    multivalued: false
 
   start:
     description: The start of the feature in positive 1-based integer coordinates

--- a/model/schema/evidence.yaml
+++ b/model/schema/evidence.yaml
@@ -1,0 +1,31 @@
+id: https://github.com/alliance-genome/agr_curation_schema/src/schema/evidence
+name: Alliance-Schema-Prototype-Evidence
+title: Alliance Schema Prototype Evidence
+
+imports:
+  - core
+  - agent
+
+classes:
+
+  Evidence:
+    is_a: AuditedObject
+    description: >-
+      Evidence associated with a class Property
+    slots:
+      - references
+      - persons
+      - authors # probably need new slot for this due to different intent of use
+      - curator_confirmed
+      - related_notes
+
+
+# Slots
+
+slots:
+
+  curator_confirmed:
+    description: >-
+      Confirmation of the annotation/association by a curator
+    domain: Evidence
+    range: Person


### PR DESCRIPTION
Here is my proposal for dealing with evidence for the allele class, although the same approach could be extended to other classes.  I believe this covers all WB's needs for the allele class, but other MODs may need additional changes.

I've gone for the approach of using specific intermediate classes to add evidence (and in some cases additional metadata, e.g. `origins`).  For example, the `generation_method` slot previously had a range of `string` whereas it now has a range of `GenerationMethod` - a class which contains the previous string and a slot pointing to an `Evidence` class.

The same thing could be achieved with associations, but I prefer this method for the following reasons:
- creates a more obvious link between the classes when browsing the model
- allows properties such as `required` and `multivalued` to be easily and obviously applied 
- I find the generated JSON schema easier to generate files for

The use of the `authors` slot in the `Evidence` class will need to be reviewed as I think the intent of the `authors` slot defined in `reference.yaml` is different to that of the WB `Author_evidence` tag (where Authors are people that cannot be unambiguously assigned to a WBPerson).

I think the only impact on the existing persistent store code is the addition of evidence to the Synonym class and the change of the way references are attached to the Note class.

Please let me know any thoughts you have on this.