### PR TITLE
SCRUM-2119 Require DQMs to submit LinkML schema version with ingest files

### DIFF
--- a/jsonschema/allianceModel.schema.json
+++ b/jsonschema/allianceModel.schema.json
@@ -7181,6 +7181,10 @@
                },
                "type": "array"
             },
+            "linkml_version": {
+               "description": "Version of LinkML schema used for submitted file in the format n.n.n (e.g. 1.2.4 or 2.0.0)",
+               "type": "string"
+            },
             "ontology_closure_ingest_set": {
                "items": {
                   "$ref": "#/$defs/OntologyTermClosure"
@@ -7200,7 +7204,9 @@
                "type": "array"
             }
          },
-         "required": [],
+         "required": [
+            "linkml_version"
+         ],
          "title": "Ingest",
          "type": "object"
       },
@@ -12979,6 +12985,10 @@
          },
          "type": "array"
       },
+      "linkml_version": {
+         "description": "Version of LinkML schema used for submitted file in the format n.n.n (e.g. 1.2.4 or 2.0.0)",
+         "type": "string"
+      },
       "ontology_closure_ingest_set": {
          "items": {
             "$ref": "#/$defs/OntologyTermClosure"
@@ -12998,7 +13008,9 @@
          "type": "array"
       }
    },
-   "required": [],
+   "required": [
+      "linkml_version"
+   ],
    "title": "AllianceModel",
    "type": "object",
    "version": "0.0.1"

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -44,6 +44,14 @@ emit_prefixes:
 
 
 slots:
+  linkml_version:
+    description: >-
+      Version of LinkML schema used for submitted file in the format n.n.n
+      (e.g. 1.2.4 or 2.0.0)
+    domain: Ingest
+    range: string
+    required: true
+
   allele_ingest_set:
     description: >-
     domain: Ingest
@@ -253,6 +261,7 @@ classes:
   Ingest:
     tree_root: true
     slots:
+      - linkml_version
       - allele_ingest_set
       - disease_allele_ingest_set
       - disease_agm_ingest_set

--- a/test/data/agm_test.json
+++ b/test/data/agm_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "agm_ingest_set": [
     {
       "curie": "ZFIN:ZDB-FISH-200601-1",

--- a/test/data/allele_association_ingest_test.json
+++ b/test/data/allele_association_ingest_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "allele_ingest_set": [
     {
       "curie": "WB:WBVar00000001",
@@ -23,7 +24,9 @@
       "predicate": "RO:0001025",
       "object": "WB:WBGene00000001",
       "evidence_code": "ECO:0000006",
-      "evidence": ["PMID:11231512"],
+      "evidence": [
+        "PMID:11231512"
+      ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
@@ -38,7 +41,9 @@
       "predicate": "RO:0001025",
       "object": "WB:WBTranscript00000001",
       "evidence_code": "ECO:0000006",
-      "evidence": ["PMID:11231512"],
+      "evidence": [
+        "PMID:11231512"
+      ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
@@ -53,7 +58,9 @@
       "predicate": "RO:0001025",
       "object": "WB:WBProtein00000001",
       "evidence_code": "ECO:0000006",
-      "evidence": ["PMID:11231512"],
+      "evidence": [
+        "PMID:11231512"
+      ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
@@ -81,7 +88,9 @@
       "predicate": "RO:0001019",
       "object": "WB:WBConstruct00000001",
       "evidence_code": "ECO:0000006",
-      "evidence": ["PMID:11231512"],
+      "evidence": [
+        "PMID:11231512"
+      ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
@@ -115,18 +124,20 @@
     }
   ],
   "allele_variant_association_ingest_set": [
-  {
-    "subject": "WB:WBVar00000001",
-    "predicate": "RO:0001019",
-    "object": "WB:WBVar00000001",
-    "evidence_code": "ECO:0000006",
-    "evidence": ["PMID:11231512"],
-    "internal": false,
-    "obsolete": false,
-    "date_created": "2015-04-09T10:15:30+00:00",
-    "date_updated": "2022-07-11T13:12:51+00:00",
-    "created_by": "WB:WBPerson002314",
-    "updated_by": "WB:WBPerson010002"
-  }
-]
+    {
+      "subject": "WB:WBVar00000001",
+      "predicate": "RO:0001019",
+      "object": "WB:WBVar00000001",
+      "evidence_code": "ECO:0000006",
+      "evidence": [
+        "PMID:11231512"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "date_created": "2015-04-09T10:15:30+00:00",
+      "date_updated": "2022-07-11T13:12:51+00:00",
+      "created_by": "WB:WBPerson002314",
+      "updated_by": "WB:WBPerson010002"
+    }
+  ]
 }

--- a/test/data/allele_slot_annotation_ingest_test.json
+++ b/test/data/allele_slot_annotation_ingest_test.json
@@ -1,9 +1,12 @@
 {
+  "linkml_version": "1.3.0",
   "allele_mutation_type_annotation_ingest_set": [
     {
       "allele_id": "WB:WBVar00000001",
       "mutation_type": "insertion",
-      "evidence": ["PMID:11231512"],
+      "evidence": [
+        "PMID:11231512"
+      ],
       "internal": false
     }
   ],
@@ -20,7 +23,9 @@
   "allele_functional_impact_annotation_ingest_set": [
     {
       "allele_id": "WB:WBVar00000001",
-      "functional_impact": ["loss-of-function"],
+      "functional_impact": [
+        "loss-of-function"
+      ],
       "evidence": [
         "PMID:11231512"
       ],
@@ -30,7 +35,9 @@
   "allele_molecular_mutation_annotation_ingest_set": [
     {
       "allele_id": "WB:WBVar00000001",
-      "molecular_mutations": ["insertion"],
+      "molecular_mutations": [
+        "insertion"
+      ],
       "evidence": [
         "PMID:11231512"
       ],
@@ -55,7 +62,8 @@
         "PMID:11231512"
       ],
       "internal": false
-    } ],
+    }
+  ],
   "allele_nomenclature_annotation_ingest_set": [
     {
       "allele_id": "WB:WBVar00000001",

--- a/test/data/allele_test.json
+++ b/test/data/allele_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "allele_ingest_set": [
     {
       "curie": "ZFIN:ZDB-ALT-130621-1",

--- a/test/data/disease_agm_test.json
+++ b/test/data/disease_agm_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "disease_agm_ingest_set": [
     {
       "evidence_codes": [

--- a/test/data/disease_allele_test.json
+++ b/test/data/disease_allele_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
       "alliance_curie": "AGRKB:100123456789013",

--- a/test/data/disease_gene_test.json
+++ b/test/data/disease_gene_test.json
@@ -1,7 +1,10 @@
 {
+  "linkml_version": "1.3.0",
   "disease_gene_ingest_set": [
     {
-      "evidence_codes": ["ECO:0000305"],
+      "evidence_codes": [
+        "ECO:0000305"
+      ],
       "alliance_curie": "AGRKB:100123456789014",
       "single_reference": "PMID:123456",
       "data_provider": "ZFIN",

--- a/test/data/fb_disease_test.json
+++ b/test/data/fb_disease_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
       "alliance_curie": "AGRKB:100123456789015",
@@ -6,7 +7,9 @@
       "predicate": "is_implicated_in",
       "object": "DOID:3191",
       "negated": false,
-      "evidence_codes": ["ECO:0007013"],
+      "evidence_codes": [
+        "ECO:0007013"
+      ],
       "single_reference": "FB:FBrf0227496",
       "annotation_type": "manually_curated",
       "data_provider": "FB",
@@ -24,7 +27,9 @@
       "predicate": "is_implicated_in",
       "object": "DOID:422",
       "negated": false,
-      "evidence_codes": ["ECO:0007013"],
+      "evidence_codes": [
+        "ECO:0007013"
+      ],
       "single_reference": "FB:FBrf0211153",
       "annotation_type": "manually_curated",
       "data_provider": "FB",

--- a/test/data/gene_test.json
+++ b/test/data/gene_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "gene_ingest_set": [
     {
       "curie": "ZFIN:ZDB-GENE-010226-1",
@@ -29,8 +30,7 @@
           "created_by": "ZFIN",
           "updated_by": "ZFIN",
           "internal": false,
-          "page_areas": [
-          ],
+          "page_areas": [],
           "prefix": "NCBI_Gene",
           "display_name": ""
         }

--- a/test/data/invalid/allele_invalid.json
+++ b/test/data/invalid/allele_invalid.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "allele_ingest_set": [
     {
       "additional_propertie": "this is invalid",

--- a/test/data/invalid/disease_allele_invalid.json
+++ b/test/data/invalid/disease_allele_invalid.json
@@ -1,11 +1,14 @@
 {
+  "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
       "evidence_code": [
         "TAS"
       ],
       "single_reference": "PMID:0012345",
-      "data_provider": ["ZFIN"],
+      "data_provider": [
+        "ZFIN"
+      ],
       "subjectTO": "ZFIN:ZDB-ALT-001122-1",
       "predicate": "is model of",
       "object": "DOID:0001234",

--- a/test/data/invalid/missing_version.json
+++ b/test/data/invalid/missing_version.json
@@ -1,0 +1,30 @@
+{
+  "agm_ingest_set": [
+    {
+      "curie": "ZFIN:ZDB-FISH-200601-1",
+      "taxon": "NCBITaxon:7955",
+      "created_by": "ZFIN",
+      "updated_by": "ZFIN",
+      "internal": false,
+      "name": "TL + MO1-hars",
+      "synonyms": [
+        {
+          "name": "test",
+          "internal": false
+        },
+        {
+          "name": "another test",
+          "internal": false
+        }
+      ],
+      "secondary_identifiers": [
+        "ZFIN:ZDB-FISH-123456-1"
+      ],
+      "references": [],
+      "sequence_targeting_reagents": [
+        "ZFIN:ZDB-MRPHLNO-191104-1"
+      ],
+      "subtype": "fish"
+    }
+  ]
+}

--- a/test/data/invalid/variant_invalid.json
+++ b/test/data/invalid/variant_invalid.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "variant_ingest_set": [
     {
       "variant_genome_locations": [
@@ -10,7 +11,6 @@
           "reference_sequence": "C",
           "variant_sequence": "T",
           "internal": false
-
         }
       ],
       "variant_status": "public",

--- a/test/data/ontology_closure_test.json
+++ b/test/data/ontology_closure_test.json
@@ -1,39 +1,54 @@
 {
+  "linkml_version": "1.3.0",
   "ontology_closure_ingest_set": [
     {
       "subject": "ZFA:brain",
       "object": "ZFA:cavitated_compound_organ",
-      "relationship_type": ["RO:is_a"],
+      "relationship_type": [
+        "RO:is_a"
+      ],
       "internal": false
     },
     {
       "subject": "ZFA:brain",
       "object": "ZFA:compound_organ",
-      "relationship_type": ["RO:is_a"],
+      "relationship_type": [
+        "RO:is_a"
+      ],
       "internal": false
     },
     {
       "subject": "ZFA:brain",
       "object": "ZFA:anatomical_structure",
-      "relationship_type": ["RO:is_a"],
+      "relationship_type": [
+        "RO:is_a"
+      ],
       "internal": false
     },
     {
       "subject": "ZFA:brain",
       "object": "ZFA:zebrafish_anatomical_entity",
-      "relationship_type": ["RO:is_a"],
+      "relationship_type": [
+        "RO:is_a"
+      ],
       "internal": false
     },
     {
       "subject": "ZFA:brain",
       "object": "ZFA:whole_organism",
-      "relationship_type": ["RO:is_a", "RO:part_of"],
+      "relationship_type": [
+        "RO:is_a",
+        "RO:part_of"
+      ],
       "internal": false
     },
     {
       "subject": "ZFA:brain",
       "object": "ZFA:whole_organism",
-      "relationship_type": ["RO:is_a", "RO:part_of"],
+      "relationship_type": [
+        "RO:is_a",
+        "RO:part_of"
+      ],
       "internal": false
     }
   ]

--- a/test/data/sgd_disease_test.json
+++ b/test/data/sgd_disease_test.json
@@ -1,32 +1,33 @@
 {
-    "disease_gene_ingest_set": [
-        {
-            "evidence_codes": [
-                "ECO:0000250",
-                "ECO:0000316"
-            ],
-            "alliance_curie": "AGRKB:100123456789017",
-            "annotation_type": "manually curated",
-            "single_reference": "PMID:21145416",
-            "data_provider": "SGD",
-            "object": "DOID:10588",
-            "created_by": "SGD",
-            "updated_by": "SGD",
-            "internal": false,
-            "date_created": "2018-04-25T14:04:15-00:00",
-            "subject": "SGD:S000001671",
-            "related_notes": [
+  "linkml_version": "1.3.0",
+  "disease_gene_ingest_set": [
+    {
+      "evidence_codes": [
+        "ECO:0000250",
+        "ECO:0000316"
+      ],
+      "alliance_curie": "AGRKB:100123456789017",
+      "annotation_type": "manually curated",
+      "single_reference": "PMID:21145416",
+      "data_provider": "SGD",
+      "object": "DOID:10588",
+      "created_by": "SGD",
+      "updated_by": "SGD",
+      "internal": false,
+      "date_created": "2018-04-25T14:04:15-00:00",
+      "subject": "SGD:S000001671",
+      "related_notes": [
         {
           "free_text": "Yeast PXA2 is homologous to human ABCD1 and ABCD2, and has been used to study adrenoleukodystrophy",
           "note_type": "disease_summary",
           "internal": false
         }
-      ], 
-            "predicate": "is_implicated_in",
-            "with": [
-                "HGNC:61",
-                "HGNC:66"
-            ]
-        }
-    ]
+      ],
+      "predicate": "is_implicated_in",
+      "with": [
+        "HGNC:61",
+        "HGNC:66"
+      ]
+    }
+  ]
 }

--- a/test/data/sqtr_test.json
+++ b/test/data/sqtr_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "sqtr_ingest_set": [
     {
       "curie": "ZFIN:ZDB-TALEN-200601-1",

--- a/test/data/variant_allele_association_test.json
+++ b/test/data/variant_allele_association_test.json
@@ -1,11 +1,16 @@
 {
-  "allele_variant_association_ingest_set": [{
-    "created_by": "ZFIN",
-    "updated_by": "ZFIN",
-    "internal": false,
-    "subject": "ZFIN:ZDB-ALT-000412-8",
-    "object": "ZFIN:ZDB-ALT-000412-8",
-    "predicate": "RO:0002525",
-    "evidence": ["ZFIN:ZDB-PUB-010101-1"]
-  }]
+  "linkml_version": "1.3.0",
+  "allele_variant_association_ingest_set": [
+    {
+      "created_by": "ZFIN",
+      "updated_by": "ZFIN",
+      "internal": false,
+      "subject": "ZFIN:ZDB-ALT-000412-8",
+      "object": "ZFIN:ZDB-ALT-000412-8",
+      "predicate": "RO:0002525",
+      "evidence": [
+        "ZFIN:ZDB-PUB-010101-1"
+      ]
+    }
+  ]
 }

--- a/test/data/variant_test.json
+++ b/test/data/variant_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "variant_ingest_set": [
     {
       "curie": "ZFIN:ZDB-ALT-000412-8",

--- a/test/data/wb_disease_test.json
+++ b/test/data/wb_disease_test.json
@@ -1,4 +1,5 @@
 {
+  "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
       "condition_relations": [
@@ -33,7 +34,8 @@
         }
       ],
       "evidence_codes": [
-        "ECO:0000315","ECO:0007013"
+        "ECO:0000315",
+        "ECO:0007013"
       ],
       "genetic_sex": "hermaphrodite",
       "mod_entity_id": "WBDOannot00001032",
@@ -42,7 +44,7 @@
       "negated": false,
       "object": "DOID:11724",
       "predicate": "is_implicated_in",
-      "single_reference":"PMID:19648295",
+      "single_reference": "PMID:19648295",
       "subject": "WB:WBVar00087752"
     }
   ],
@@ -75,7 +77,9 @@
       ],
       "disease_genetic_modifier": "WB:WBStrain00035193",
       "disease_genetic_modifier_relation": "ameliorated_by",
-      "evidence_codes": ["ECO:0000315", "ECO:0007013"
+      "evidence_codes": [
+        "ECO:0000315",
+        "ECO:0007013"
       ],
       "genetic_sex": "hermaphrodite",
       "mod_entity_id": "WBDOannot00001014",
@@ -84,9 +88,9 @@
       "internal": false,
       "object": "DOID:1826",
       "predicate": "is_implicated_in",
-      "single_reference":"PMID:19648295",
+      "single_reference": "PMID:19648295",
       "subject": "WB:WBGene00011955"
-      }
+    }
   ],
   "disease_agm_ingest_set": [
     {
@@ -96,7 +100,9 @@
       "date_updated": "2019-03-08T00:00:00+00:00",
       "disease_genetic_modifier": "WB:WBVar00250993",
       "disease_genetic_modifier_relation": "exacerbated_by",
-      "evidence_codes": ["ECO:0000315","ECO:0007013"
+      "evidence_codes": [
+        "ECO:0000315",
+        "ECO:0007013"
       ],
       "genetic_sex": "hermaphrodite",
       "mod_entity_id": "WBDOannot00000109",
@@ -104,7 +110,7 @@
       "internal": false,
       "object": "DOID:10652",
       "predicate": "is_model_of",
-      "single_reference":"PMID:19648295",
+      "single_reference": "PMID:19648295",
       "subject": "WB:WBStrain00005094",
       "inferred_allele": "WB:WBTransgene00000410"
     },
@@ -140,14 +146,17 @@
           "internal": false
         }
       ],
-      "evidence_codes": ["ECO:0000315","ECO:0007013"],
+      "evidence_codes": [
+        "ECO:0000315",
+        "ECO:0007013"
+      ],
       "genetic_sex": "hermaphrodite",
       "mod_entity_id": "WBDOannot00000110",
       "updated_by": "WB:WBPerson324",
       "internal": false,
       "object": "DOID:11723",
       "predicate": "is_model_of",
-      "single_reference":"PMID:19648295",
+      "single_reference": "PMID:19648295",
       "subject": "WB:WBStrain00024340",
       "asserted_allele": "WB:WBVar00054722"
     }


### PR DESCRIPTION
This will allow us to prevent reloading previously submitted files that were submitted to LinkML schema versions incompatible with current Java code.