### PR TITLE
Add 'disease_annotation_curie' to DiseaseAnnotation class

### DIFF
--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -417,13 +417,6 @@ slots:
     range: uriorcurie
     identifier: true
 
-  alliance_curie:
-    multivalued: false
-    description: >-
-      A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI,
-      prefix must be AGRKB, generated at alliance.
-    range: uriorcurie
-
   unique_id:
     description: >-
       A non-curie unique identifier for a thing.

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -118,7 +118,7 @@ classes:
     is_a: PhenotypeAnnotation
     slots:
       - inferred_gene
-      - asserted_gene
+      - asserted_genes
     slot_usage:
       subject:
         description: >-
@@ -133,7 +133,7 @@ classes:
           The gene to which the phenotype is inferred to be associated.
         required: false
         range: Gene
-      asserted_gene:
+      asserted_genes:
         required: false
       asserted_allele:
         required: false
@@ -146,7 +146,7 @@ classes:
     slots:
       - inferred_allele
       - inferred_gene
-      - asserted_gene
+      - asserted_genes
       - asserted_allele
     slot_usage:
       subject:
@@ -167,7 +167,7 @@ classes:
           The allele to which the phenotype is inferred to be associated.
         required: false
         range: Allele
-      asserted_gene:
+      asserted_genes:
         required: false
       asserted_allele:
         required: false
@@ -287,7 +287,7 @@ classes:
     is_a: DiseaseAnnotation
     slots:
       - inferred_gene
-      - asserted_gene
+      - asserted_genes
     slot_usage:
       subject:
         description: >-
@@ -304,7 +304,7 @@ classes:
           The gene to which the disease is inferred to be associated.
         required: false
         range: Gene
-      asserted_gene:
+      asserted_genes:
         required: false
 
   AGMDiseaseAnnotation:
@@ -315,7 +315,7 @@ classes:
     slots:
       - inferred_allele
       - inferred_gene
-      - asserted_gene
+      - asserted_genes
       - asserted_allele
     slot_usage:
       subject:
@@ -338,7 +338,7 @@ classes:
           The allele to which the disease is inferred to be associated.
         required: false
         range: Allele
-      asserted_gene:
+      asserted_genes:
         required: false
       asserted_allele:
         required: false
@@ -457,10 +457,12 @@ slots:
       The allele to which something is manually asserted to be associated.
     range: Allele
 
-  asserted_gene:
+  asserted_genes:
+    singular_name: asserted_gene
     description: >-
-      The gene to which something is manually asserted to be associated.
+      The gene(s) to which something is manually asserted to be associated.
     range: Gene
+    multivalued: true
 
   condition_anatomy:
     domain: ExperimentalCondition

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -179,7 +179,7 @@ classes:
     description: >-
       An annotation asserting an association between a biological entity and a disease supported by evidence.
     slots:
-      - alliance_curie
+      - disease_annotation_curie
       - unique_id
       - mod_entity_id
       - negated
@@ -446,6 +446,22 @@ classes:
 
 slots:
 
+  annotation_type:
+    range: VocabularyTerm
+    description: >-
+      The type of annotation classified according to curation method. Submitted
+      value should be a vocabulary term from the 'Annotation types' vocabulary
+
+  asserted_allele:
+    description: >-
+      The allele to which something is manually asserted to be associated.
+    range: Allele
+
+  asserted_gene:
+    description: >-
+      The gene to which something is manually asserted to be associated.
+    range: Gene
+
   condition_anatomy:
     domain: ExperimentalCondition
     range: AnatomicalTerm
@@ -468,9 +484,16 @@ slots:
     domain: ExperimentalCondition
     range: ZECOTerm
 
+  condition_free_text:
+    description: >-
+      Free-text description of the experimental condition
+    required: false
+    domain: ExperimentalCondition
+    range: string
+
   condition_gene_ontology:
     domain: ExperimentalCondition
-    range: GOTerm                     # Update to GOTerm if such a class is instantiated
+    range: GOTerm
 
   condition_id:
     domain: ExperimentalCondition
@@ -479,6 +502,19 @@ slots:
   condition_quantity:
     domain: ExperimentalCondition
     range: string
+
+  condition_relation_type:
+    description: >-
+      Submitted value should be a vocabulary term from the 'Condition relation
+      types' vocabulary
+    domain: ConditionRelation
+    range: VocabularyTerm
+
+  condition_relations:
+    range: ConditionRelation
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
 
   condition_statement:
     description: >-
@@ -497,29 +533,9 @@ slots:
     domain: ExperimentalCondition
     range: string
 
-  condition_free_text:
-    description: >-
-      Free-text description of the experimental condition
-    required: false
-    domain: ExperimentalCondition
-    range: string
-
   condition_taxon:
     domain: ExperimentalCondition
     range: NCBITaxonTerm
-
-  condition_relations:
-    range: ConditionRelation
-    multivalued: true
-    inlined: true
-    inlined_as_list: true
-
-  condition_relation_type:
-    description: >-
-      Submitted value should be a vocabulary term from the 'Condition relation
-      types' vocabulary
-    domain: ConditionRelation
-    range: VocabularyTerm
 
   conditions:
     range: ExperimentalCondition
@@ -527,25 +543,28 @@ slots:
     inlined: true
     inlined_as_list: true
 
-  inferred_gene:
+  disease_annotation_curie:
     description: >-
-      The gene to which something is inferred to be associated.
-    range: Gene
+      The Alliance-minted curie (unique identifier) for the disease annotation of the form:
+      AGRKB:100123456789012 (class code: 100). This is not required upon ingest
+      from DQM disease annotation file submissions to the persistent store, but will
+      be generated Alliance-side post-ingest with the MaTI system.
+    range: uriorcurie
+    required: false
+    identifier: false
+    multivalued: false
 
-  inferred_allele:
+  disease_genetic_modifier:
     description: >-
-      The allele to which something is inferred to be associated.
-    range: Allele
+      Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.
+    required: false
 
-  asserted_gene:
+  disease_genetic_modifier_relation:
     description: >-
-      The gene to which something is manually asserted to be associated.
-    range: Gene
-
-  asserted_allele:
-    description: >-
-      The allele to which something is manually asserted to be associated.
-    range: Allele
+      A relation describing how the genetic modifier modifies the disease model.
+      Submitted value should be a vocabulary term from the 'Disease genetic
+      modifiers' vocabulary
+    range: VocabularyTerm
 
   disease_qualifiers:
     description: >-
@@ -561,29 +580,27 @@ slots:
       vocabulary
     range: VocabularyTerm
 
-  sgd_strain_background:
-    range: AffectedGenomicModel
-
-  annotation_type:
-    range: VocabularyTerm
+  handle:
     description: >-
-      The type of annotation classified according to curation method. Submitted
-      value should be a vocabulary term from the 'Annotation types' vocabulary
+      A slot pointing to a free-text alias or 'handle' for a data object, such as
+      a reference-specific alias for a data object used while curating.
+    range: string
 
-  disease_genetic_modifier:
+  inferred_gene:
     description: >-
-      Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.
-    required: false
+      The gene to which something is inferred to be associated.
+    range: Gene
 
-  disease_genetic_modifier_relation:
+  inferred_allele:
     description: >-
-      A relation describing how the genetic modifier modifies the disease model.
-      Submitted value should be a vocabulary term from the 'Disease genetic
-      modifiers' vocabulary
-    range: VocabularyTerm
+      The allele to which something is inferred to be associated.
+    range: Allele
 
   phenotype_term:
     range: PhenotypeTerm
+
+  sgd_strain_background:
+    range: AffectedGenomicModel
 
   with:
     description: >-
@@ -591,8 +608,4 @@ slots:
     range: Gene
     multivalued: true
 
-  handle:
-    description: >-
-      A slot pointing to a free-text alias or 'handle' for a data object, such as
-      a reference-specific alias for a data object used while curating.
-    range: string
+

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -196,7 +196,7 @@ classes:
       - disease_genetic_modifier
       - disease_genetic_modifier_relation
     slot_usage:
-      alliance_curie:
+      disease_annotation_curie:
         description: >-
           The Alliance-minted ID for the disease annotation. The ID is of the format
           AGRKB:100000000000001, where the first three digits represent the

--- a/test/data/disease_agm_test.json
+++ b/test/data/disease_agm_test.json
@@ -5,7 +5,7 @@
       "evidence_codes": [
         "ECO:0000305"
       ],
-      "alliance_curie": "AGRKB:100123456789014",
+      "disease_annotation_curie": "AGRKB:100123456789014",
       "single_reference": "PMID:123456",
       "data_provider": "ZFIN",
       "object": "DOID:9452",

--- a/test/data/disease_allele_test.json
+++ b/test/data/disease_allele_test.json
@@ -11,7 +11,9 @@
       "subject": "ZFIN:ZDB-ALT-001122-1",
       "predicate": "is_implicated_in",
       "object": "DOID:0001234",
-      "asserted_gene": "ZFIN:ZDB-GENE-060503-338",
+      "asserted_genes": [
+        "ZFIN:ZDB-GENE-060503-338"
+      ],
       "created_by": "ZFIN",
       "updated_by": "ZFIN",
       "internal": false

--- a/test/data/disease_allele_test.json
+++ b/test/data/disease_allele_test.json
@@ -2,7 +2,7 @@
   "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
-      "alliance_curie": "AGRKB:100123456789013",
+      "disease_annotation_curie": "AGRKB:100123456789013",
       "evidence_codes": [
         "ECO:0000305"
       ],

--- a/test/data/disease_gene_test.json
+++ b/test/data/disease_gene_test.json
@@ -5,7 +5,7 @@
       "evidence_codes": [
         "ECO:0000305"
       ],
-      "alliance_curie": "AGRKB:100123456789014",
+      "disease_annotation_curie": "AGRKB:100123456789014",
       "single_reference": "PMID:123456",
       "data_provider": "ZFIN",
       "object": "DOID:0001234",

--- a/test/data/fb_disease_test.json
+++ b/test/data/fb_disease_test.json
@@ -2,7 +2,7 @@
   "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
-      "alliance_curie": "AGRKB:100123456789015",
+      "disease_annotation_curie": "AGRKB:100123456789015",
       "subject": "FB:FBal0000272",
       "predicate": "is_implicated_in",
       "object": "DOID:3191",
@@ -22,7 +22,7 @@
   ],
   "disease_gene_ingest_set": [
     {
-      "alliance_curie": "AGRKB:100123456789016",
+      "disease_annotation_curie": "AGRKB:100123456789016",
       "subject": "FB:FBgn0000047",
       "predicate": "is_implicated_in",
       "object": "DOID:422",

--- a/test/data/sgd_disease_test.json
+++ b/test/data/sgd_disease_test.json
@@ -6,7 +6,7 @@
         "ECO:0000250",
         "ECO:0000316"
       ],
-      "alliance_curie": "AGRKB:100123456789017",
+      "disease_annotation_curie": "AGRKB:100123456789017",
       "annotation_type": "manually curated",
       "single_reference": "PMID:21145416",
       "data_provider": "SGD",

--- a/test/data/wb_disease_test.json
+++ b/test/data/wb_disease_test.json
@@ -22,7 +22,7 @@
           ]
         }
       ],
-      "alliance_curie": "AGRKB:100123456789018",
+      "disease_annotation_curie": "AGRKB:100123456789018",
       "data_provider": "WB",
       "created_by": "WB:WBPerson324",
       "date_updated": "2021-09-01T00:00:00+00:00",
@@ -64,7 +64,7 @@
           ]
         }
       ],
-      "alliance_curie": "AGRKB:100123456789019",
+      "disease_annotation_curie": "AGRKB:100123456789019",
       "data_provider": "WB",
       "created_by": "WB:WBPerson324",
       "date_updated": "2021-08-24T00:00:00+00:00",
@@ -95,7 +95,7 @@
   "disease_agm_ingest_set": [
     {
       "created_by": "WB:WBPerson324",
-      "alliance_curie": "AGRKB:100123456789020",
+      "disease_annotation_curie": "AGRKB:100123456789020",
       "data_provider": "WB",
       "date_updated": "2019-03-08T00:00:00+00:00",
       "disease_genetic_modifier": "WB:WBVar00250993",
@@ -136,7 +136,7 @@
         }
       ],
       "created_by": "WB:WBPerson324",
-      "alliance_curie": "AGRKB:100123456789021",
+      "disease_annotation_curie": "AGRKB:100123456789021",
       "data_provider": "WB",
       "date_updated": "2017-05-22T00:00:00+00:00",
       "related_notes": [


### PR DESCRIPTION
-replaced 'alliance_curie' in DiseaseAnnotation class with 'disease_annotation_curie' slot
- added slot definition for 'disease_annotation_curie'
- alphabetized slot definitions in phenotypeAndDiseaseAnnotation.yaml
- removed comment TO DO item for GOTerm