### PR TITLE
Replace allele_id with single_allele

### DIFF
--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -74,7 +74,7 @@ classes:
   AlleleSlotAnnotation:
     is_a: SlotAnnotation
     slots:
-      - allele_id
+      - single_allele
       - evidence
 
   AlleleMutationTypeAnnotation:
@@ -223,7 +223,7 @@ classes:
       primary_image:
         description: >-
           Can be null; if false, maybe you would show all the images.
-          We need to revisit this issue. 
+          We need to revisit this issue.
 
   AlleleNotesAssociation:
     is_a: Association
@@ -322,32 +322,32 @@ slots:
 
   primary_image:
     description: >-
-      The primary image for an allele that is used to represent the allele on a page. 
+      The primary image for an allele that is used to represent the allele on a page.
 
   origin:
     range: boolean
 
-  allele_id:
-    range: uriorcurie
+  single_allele:
+    range: Allele
 
   mutagenesis_method:
     alias: ["mutagen"]
     range: VocabularyTerm
     description: >-
       Technique used to create the allele, e.g.
-      spontaneous / naturally occurring / radiation-induced / recombinant / 
+      spontaneous / naturally occurring / radiation-induced / recombinant /
       ENU / CRISPR / TALEN / gamma rays / not specified / spontaneous / DNA /
       DNA AND CRISPR / DNA and TALEN / zinc finger nuclease / EMS
 
   mutagenesis_target:
     alias: ["mutagee"]
     description: >-
-      The target of the mutation, e.g. strain / adult females / 
+      The target of the mutation, e.g. strain / adult females /
       adult males / embryos / sperm / not specified
     range: string # VocabularyTerm?
 
   mutation_target_strain:
-    description: >- 
+    description: >-
       The particular strain (solely for and from MGI) that is targeted
       by the generation method for a particular allele.
     range: string # VocabularyTerm?

--- a/test/data/allele_slot_annotation_ingest_test.json
+++ b/test/data/allele_slot_annotation_ingest_test.json
@@ -2,7 +2,7 @@
   "linkml_version": "1.3.0",
   "allele_mutation_type_annotation_ingest_set": [
     {
-      "allele_id": "WB:WBVar00000001",
+      "single_allele": "WB:WBVar00000001",
       "mutation_type": "insertion",
       "evidence": [
         "PMID:11231512"
@@ -12,7 +12,7 @@
   ],
   "allele_germline_transmission_status_annotation_ingest_set": [
     {
-      "allele_id": "WB:WBVar00000001",
+      "single_allele": "WB:WBVar00000001",
       "germline_transmission_status": "germline",
       "evidence": [
         "PMID:11231512"
@@ -22,7 +22,7 @@
   ],
   "allele_functional_impact_annotation_ingest_set": [
     {
-      "allele_id": "WB:WBVar00000001",
+      "single_allele": "WB:WBVar00000001",
       "functional_impact": [
         "loss-of-function"
       ],
@@ -34,7 +34,7 @@
   ],
   "allele_molecular_mutation_annotation_ingest_set": [
     {
-      "allele_id": "WB:WBVar00000001",
+      "single_allele": "WB:WBVar00000001",
       "molecular_mutations": [
         "insertion"
       ],
@@ -46,7 +46,7 @@
   ],
   "allele_database_status_annotation_ingest_set": [
     {
-      "allele_id": "WB:WBVar00000001",
+      "single_allele": "WB:WBVar00000001",
       "database_status": "public",
       "evidence": [
         "PMID:11231512"
@@ -56,7 +56,7 @@
   ],
   "allele_secondary_id_annotation_ingest_set": [
     {
-      "allele_id": "WB:WBVar00000001",
+      "single_allele": "WB:WBVar00000001",
       "secondary_id": "WBVar00000001",
       "evidence": [
         "PMID:11231512"
@@ -66,7 +66,7 @@
   ],
   "allele_nomenclature_annotation_ingest_set": [
     {
-      "allele_id": "WB:WBVar00000001",
+      "single_allele": "WB:WBVar00000001",
       "nomenclature_event": "named",
       "evidence": [
         "PMID:11231512"


### PR DESCRIPTION
@sierra-moxon Can we do this switch for allele_id in the AlleleSlotAnnotation?  We would want to implement this field as an Allele object in our Java entity classes.