### PR TITLE
Change required properties for Allele

### DIFF
--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -61,7 +61,7 @@ classes:
         description: synonyms for allele names and synonyms
       aberration:
         notes: specific to FB
-      name:
+      symbol:
         required: true
 
   GenerationMethod:

--- a/test/data/allele_test.json
+++ b/test/data/allele_test.json
@@ -7,7 +7,7 @@
       "created_by": "ZFIN",
       "updated_by": "ZFIN",
       "internal": false,
-      "name": "b1219"
+      "symbol": "b1219"
     },
     {
       "curie": "ZFIN:ZDB-ALT-130411-947",
@@ -15,7 +15,7 @@
       "created_by": "ZFIN",
       "updated_by": "ZFIN",
       "internal": false,
-      "name": "sa11077"
+      "symbol": "sa11077"
     }
   ]
 }


### PR DESCRIPTION
For the Allele class, 'name' should not be required but 'symbol' should be