### PR TITLE
Proposal for separation of ingest and database concerns in LinkML model

### DIFF
--- a/jsonschema/allianceModel.schema.json
+++ b/jsonschema/allianceModel.schema.json
@@ -4,10 +4,6 @@
          "additionalProperties": false,
          "description": "An annotation asserting an association between an AGM and a disease supported by evidence.",
          "properties": {
-            "alliance_curie": {
-               "description": "The Alliance-minted ID for the disease annotation. The ID is of the format AGRKB:100000000000001, where the first three digits represent the DiseaseAnnotation class code of \"100\", followed by a 12-digit identifier",
-               "type": "string"
-            },
             "annotation_type": {
                "description": "The type of annotation classified according to curation method. Submitted value should be a vocabulary term from the 'Annotation types' vocabulary",
                "type": "string"
@@ -16,9 +12,12 @@
                "description": "The allele to which something is manually asserted to be associated.",
                "type": "string"
             },
-            "asserted_gene": {
-               "description": "The gene to which something is manually asserted to be associated.",
-               "type": "string"
+            "asserted_genes": {
+               "description": "The gene(s) to which something is manually asserted to be associated.",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
             },
             "condition_relations": {
                "items": {
@@ -28,6 +27,10 @@
             },
             "created_by": {
                "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "curie": {
+               "description": "The Alliance-minted ID for the disease annotation. The ID is of the format AGRKB:100000000000001, where the first three digits represent the DiseaseAnnotation class code of \"100\", followed by a 12-digit identifier",
                "type": "string"
             },
             "data_provider": {
@@ -155,6 +158,7 @@
          },
          "required": [
             "internal",
+            "curie",
             "evidence_codes",
             "single_reference",
             "data_provider",
@@ -165,6 +169,162 @@
          "title": "AGMDiseaseAnnotation",
          "type": "object"
       },
+      "AGMDiseaseAnnotationDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for an association between an AGM and a disease",
+         "properties": {
+            "agm_curie": {
+               "type": "string"
+            },
+            "annotation_type_name": {
+               "description": "Name of the VocabularyTerm describing the annotation type",
+               "type": "string"
+            },
+            "asserted_allele_curie": {
+               "description": "Curie of the allele to which something is manually asserted to be associated",
+               "type": "string"
+            },
+            "asserted_gene_curies": {
+               "description": "Curies of the gene(s) to which something is manually asserted to be associated",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "condition_relation_dtos": {
+               "items": {
+                  "$ref": "#/$defs/ConditionRelationDTO"
+               },
+               "type": "array"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "data_provider": {
+               "description": "Organization (e.g. MOD) from which the data was sourced",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "disease_genetic_modifier_curie": {
+               "description": "Curie of BiologcalEntity that modifies the disease model",
+               "type": "string"
+            },
+            "disease_genetic_modifier_relation_name": {
+               "description": "Name of the VocabularyTerm from the 'Disease genetic modifiers' vocabulary that describes how the genetic modifier modifies the disease model.",
+               "type": "string"
+            },
+            "disease_qualifier_names": {
+               "description": "Names of terms from the 'Disease qualifiers' vocabulary",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "disease_relation_name": {
+               "description": "Name of term from 'Disease Relation Vocabulary' vocabulary",
+               "type": "string"
+            },
+            "do_term_curie": {
+               "description": "Curie of DOTerm describing the disease",
+               "type": "string"
+            },
+            "evidence_code_curies": {
+               "description": "List of ECOTerm curies",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "genetic_sex_name": {
+               "description": "Name of term from the 'Genetic sexes' vocabulary",
+               "type": "string"
+            },
+            "inferred_allele_curie": {
+               "description": "Curie of allele to which something is inferred to be associated via an automated pipeline",
+               "type": "string"
+            },
+            "inferred_gene_curie": {
+               "description": "Curie of gene to which something is inferred to be associated via an automated pipeline",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "mod_entity_id": {
+               "description": "The model organism database (MOD) identifier/curie for the object",
+               "type": "string"
+            },
+            "negated": {
+               "description": "if set to true, then the association is negated i.e. is not true",
+               "type": "boolean"
+            },
+            "note_dtos": {
+               "items": {
+                  "$ref": "#/$defs/NoteDTO"
+               },
+               "type": "array"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "reference_curie": {
+               "description": "External reference curie used for ingest",
+               "type": "string"
+            },
+            "secondary_data_provider": {
+               "description": "Organization (e.g. MOD) that provided the data directly to the Alliance, but not the original source",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            },
+            "with_gene_curies": {
+               "description": "http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/#with-or-from-column-8",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            }
+         },
+         "required": [
+            "internal",
+            "disease_relation_name",
+            "do_term_curie",
+            "agm_curie"
+         ],
+         "title": "AGMDiseaseAnnotationDTO",
+         "type": "object"
+      },
       "AGMPhenotypeAnnotation": {
          "additionalProperties": false,
          "description": "An annotation asserting an association between an AGM and a phenotype supported by evidence.",
@@ -173,9 +333,12 @@
                "description": "The allele to which something is manually asserted to be associated.",
                "type": "string"
             },
-            "asserted_gene": {
-               "description": "The gene to which something is manually asserted to be associated.",
-               "type": "string"
+            "asserted_genes": {
+               "description": "The gene(s) to which something is manually asserted to be associated.",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
             },
             "condition_relations": {
                "items": {
@@ -476,8 +639,8 @@
                "type": "array"
             },
             "subtype": {
-               "$ref": "#/$defs/SubtypeValues",
-               "description": "Subtype of affected genomic model"
+               "description": "Subtype of affected genomic model - permissible values: strain / genotype / fish",
+               "type": "string"
             },
             "synonyms": {
                "description": "holds between a named thing and a synonym",
@@ -532,9 +695,6 @@
                "format": "date",
                "type": "string"
             },
-            "has_allele": {
-               "type": "string"
-            },
             "internal": {
                "description": "Classifies the entity as private (for internal use) or not (for public use).",
                "type": "boolean"
@@ -542,6 +702,9 @@
             "obsolete": {
                "description": "Entity is no longer current.",
                "type": "boolean"
+            },
+            "single_allele": {
+               "type": "string"
             },
             "updated_by": {
                "description": "The individual that last modified the entity.",
@@ -556,6 +719,173 @@
             "internal"
          ],
          "title": "AffectedGenomicModelComponent",
+         "type": "object"
+      },
+      "AffectedGenomicModelComponentDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "allele_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            },
+            "zygosity_curie": {
+               "description": "Curie of GENO ontology ID for allele zygosity - permissible_values: GENO:0000602 / GENO:0000603 / GENO:0000604 / GENO:0000605 / GENO:0000606 / GENO:0000135 / GENO:0000136 / GENO:0000137 / GENO:0000134",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie"
+         ],
+         "title": "AffectedGenomicModelComponentDTO",
+         "type": "object"
+      },
+      "AffectedGenomicModelDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for AGMs",
+         "properties": {
+            "component_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AffectedGenomicModelComponentDTO"
+               },
+               "type": "array"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "cross_reference_dtos": {
+               "items": {
+                  "$ref": "#/$defs/CrossReferenceDTO"
+               },
+               "type": "array"
+            },
+            "curie": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "data_provider": {
+               "description": "Organization (e.g. MOD) from which the data was sourced",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "genomic_location_dtos": {
+               "items": {
+                  "$ref": "#/$defs/GenomicLocationDTO"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "name": {
+               "description": "a human-readable name for an entity",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "reference_curies": {
+               "description": "External reference curies used for ingest",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "secondary_identifiers": {
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "sequence_targeting_reagent_curies": {
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "subtype_name": {
+               "description": "Name of VocabularyTerm describing subtype - permissible values: strain / genotype / fish",
+               "type": "string"
+            },
+            "synonym_dtos": {
+               "items": {
+                  "$ref": "#/$defs/SynonymDTO"
+               },
+               "type": "array"
+            },
+            "taxon_curie": {
+               "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "curie",
+            "taxon_curie"
+         ],
+         "title": "AffectedGenomicModelDTO",
          "type": "object"
       },
       "Agent": {
@@ -621,6 +951,60 @@
                "description": "Associated deficiency (etc.) whose breakpoint causes the mutation",
                "type": "string"
             },
+            "allele_database_status": {
+               "$ref": "#/$defs/AlleleDatabaseStatus",
+               "description": "Database status of a given allele"
+            },
+            "allele_functional_impacts": {
+               "description": "Functional impacts of a given allele",
+               "items": {
+                  "$ref": "#/$defs/AlleleFunctionalImpact"
+               },
+               "type": "array"
+            },
+            "allele_germline_transmission_status": {
+               "$ref": "#/$defs/AlleleGermlineTransmissionStatus",
+               "description": "Germline transmission status for a given allele"
+            },
+            "allele_molecular_mutations": {
+               "description": "Molecular mutations of a given allele",
+               "items": {
+                  "$ref": "#/$defs/AlleleMolecularMutation"
+               },
+               "type": "array"
+            },
+            "allele_mutation_types": {
+               "description": "Mutation types for a given allele",
+               "items": {
+                  "$ref": "#/$defs/AlleleMutationType"
+               },
+               "type": "array"
+            },
+            "allele_nomenclature_events": {
+               "description": "Nomenclature events of a given allele",
+               "items": {
+                  "$ref": "#/$defs/AlleleNomenclatureEvent"
+               },
+               "type": "array"
+            },
+            "allele_notes": {
+               "$ref": "#/$defs/AlleleNote",
+               "description": "Notes for a given allele"
+            },
+            "allele_secondary_ids": {
+               "description": "Secondary IDs of a given allele",
+               "items": {
+                  "$ref": "#/$defs/AlleleSecondaryId"
+               },
+               "type": "array"
+            },
+            "allele_synonyms": {
+               "description": "Synonyms of a given allele",
+               "items": {
+                  "$ref": "#/$defs/Synonym"
+               },
+               "type": "array"
+            },
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -666,8 +1050,8 @@
                "description": "Set of high-throughput alleles made by large projects",
                "type": "string"
             },
-            "inheritence_mode": {
-               "description": "Mode of inheritence, e.g. dominant / semi-dominant / recessive / unknown # TODO: please enumerate the difference between this and zygosity in AffectedGenomicModel class.",
+            "inheritance_mode": {
+               "description": "Mode of inheritance, e.g. dominant / semi-dominant / recessive / unknown # TODO: please enumerate the difference between this and zygosity in AffectedGenomicModel class.",
                "type": "string"
             },
             "internal": {
@@ -727,7 +1111,7 @@
             "internal",
             "curie",
             "taxon",
-            "name"
+            "symbol"
          ],
          "title": "Allele",
          "type": "object"
@@ -798,6 +1182,66 @@
             "object"
          ],
          "title": "AlleleCellLineAssociation",
+         "type": "object"
+      },
+      "AlleleCellLineAssociationDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "allele_curie": {
+               "type": "string"
+            },
+            "cell_line_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "predicate_name": {
+               "description": "Name of VocabularyTerm representing predicate of an Association",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "predicate_name",
+            "cell_line_curie"
+         ],
+         "title": "AlleleCellLineAssociationDTO",
          "type": "object"
       },
       "AlleleConstructAssociation": {
@@ -876,13 +1320,244 @@
          "title": "AlleleConstructAssociation",
          "type": "object"
       },
-      "AlleleDatabaseStatusAnnotation": {
+      "AlleleConstructAssociationDTO": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
+            "allele_curie": {
                "type": "string"
             },
+            "construct_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_code_curie": {
+               "description": "Curie of ECOTerm",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "note_dto": {
+               "$ref": "#/$defs/NoteDTO"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "ro_term_curie": {
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "ro_term_curie",
+            "evidence_curies",
+            "construct_curie"
+         ],
+         "title": "AlleleConstructAssociationDTO",
+         "type": "object"
+      },
+      "AlleleDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for an Allele object",
+         "properties": {
+            "allele_database_status_dto": {
+               "$ref": "#/$defs/AlleleDatabaseStatusDTO"
+            },
+            "allele_functional_impact_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AlleleFunctionalImpactDTO"
+               },
+               "type": "array"
+            },
+            "allele_germline_transmission_status_dto": {
+               "$ref": "#/$defs/AlleleGermlineTransmissionStatusDTO"
+            },
+            "allele_molecular_mutation_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AlleleMolecularMutationDTO"
+               },
+               "type": "array"
+            },
+            "allele_mutation_type_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AlleleMutationTypeDTO"
+               },
+               "type": "array"
+            },
+            "allele_nomenclature_event_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AlleleNomenclatureEventDTO"
+               },
+               "type": "array"
+            },
+            "allele_note_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AlleleNoteDTO"
+               },
+               "type": "array"
+            },
+            "allele_secondary_id_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AlleleSecondaryIdDTO"
+               },
+               "type": "array"
+            },
+            "allele_synonym_dtos": {
+               "items": {
+                  "$ref": "#/$defs/AlleleSynonymDTO"
+               },
+               "type": "array"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "cross_reference_dtos": {
+               "items": {
+                  "$ref": "#/$defs/CrossReferenceDTO"
+               },
+               "type": "array"
+            },
+            "curie": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "genomic_location_dtos": {
+               "items": {
+                  "$ref": "#/$defs/GenomicLocationDTO"
+               },
+               "type": "array"
+            },
+            "in_collection_name": {
+               "description": "Name of VocabularyTerm describing the collection",
+               "type": "string"
+            },
+            "inheritance_mode_name": {
+               "description": "Name of VocabularyTerm describing the inheritance mode",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "is_extinct": {
+               "description": "Does the allele still exist in a population somewhere?",
+               "type": "boolean"
+            },
+            "name": {
+               "description": "a human-readable name for an entity",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "reference_curies": {
+               "description": "External reference curies used for ingest",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "secondary_identifiers": {
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "sequencing_status_name": {
+               "description": "Name of VocabularyTerm describing the sequencing status",
+               "type": "string"
+            },
+            "symbol": {
+               "description": "Symbol for a particular thing",
+               "type": "string"
+            },
+            "synonym_dtos": {
+               "items": {
+                  "$ref": "#/$defs/SynonymDTO"
+               },
+               "type": "array"
+            },
+            "taxon_curie": {
+               "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "curie",
+            "taxon_curie"
+         ],
+         "title": "AlleleDTO",
+         "type": "object"
+      },
+      "AlleleDatabaseStatus": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -925,6 +1600,9 @@
                "description": "Entity is no longer current.",
                "type": "boolean"
             },
+            "single_allele": {
+               "type": "string"
+            },
             "updated_by": {
                "description": "The individual that last modified the entity.",
                "type": "string"
@@ -933,24 +1611,81 @@
          "required": [
             "internal"
          ],
-         "title": "AlleleDatabaseStatusAnnotation",
+         "title": "AlleleDatabaseStatus",
+         "type": "object"
+      },
+      "AlleleDatabaseStatusDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by": {
+               "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "database_status_name": {
+               "description": "Name of the VocabularyTerm describing the database status",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by": {
+               "description": "The individual that last modified the entity.",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleDatabaseStatusDTO",
          "type": "object"
       },
       "AlleleDiseaseAnnotation": {
          "additionalProperties": false,
          "description": "An annotation asserting an association between an allele and a disease supported by evidence.",
          "properties": {
-            "alliance_curie": {
-               "description": "The Alliance-minted ID for the disease annotation. The ID is of the format AGRKB:100000000000001, where the first three digits represent the DiseaseAnnotation class code of \"100\", followed by a 12-digit identifier",
-               "type": "string"
-            },
             "annotation_type": {
                "description": "The type of annotation classified according to curation method. Submitted value should be a vocabulary term from the 'Annotation types' vocabulary",
                "type": "string"
             },
-            "asserted_gene": {
-               "description": "The gene to which something is manually asserted to be associated.",
-               "type": "string"
+            "asserted_genes": {
+               "description": "The gene(s) to which something is manually asserted to be associated.",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
             },
             "condition_relations": {
                "items": {
@@ -960,6 +1695,10 @@
             },
             "created_by": {
                "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "curie": {
+               "description": "The Alliance-minted ID for the disease annotation. The ID is of the format AGRKB:100000000000001, where the first three digits represent the DiseaseAnnotation class code of \"100\", followed by a 12-digit identifier",
                "type": "string"
             },
             "data_provider": {
@@ -1083,6 +1822,7 @@
          },
          "required": [
             "internal",
+            "curie",
             "evidence_codes",
             "single_reference",
             "data_provider",
@@ -1093,13 +1833,158 @@
          "title": "AlleleDiseaseAnnotation",
          "type": "object"
       },
-      "AlleleFunctionalImpactAnnotation": {
+      "AlleleDiseaseAnnotationDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for an association between an allele and a disease",
+         "properties": {
+            "allele_curie": {
+               "type": "string"
+            },
+            "annotation_type_name": {
+               "description": "Name of the VocabularyTerm describing the annotation type",
+               "type": "string"
+            },
+            "asserted_gene_curies": {
+               "description": "Curies of the gene(s) to which something is manually asserted to be associated",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "condition_relation_dtos": {
+               "items": {
+                  "$ref": "#/$defs/ConditionRelationDTO"
+               },
+               "type": "array"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "data_provider": {
+               "description": "Organization (e.g. MOD) from which the data was sourced",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "disease_genetic_modifier_curie": {
+               "description": "Curie of BiologcalEntity that modifies the disease model",
+               "type": "string"
+            },
+            "disease_genetic_modifier_relation_name": {
+               "description": "Name of the VocabularyTerm from the 'Disease genetic modifiers' vocabulary that describes how the genetic modifier modifies the disease model.",
+               "type": "string"
+            },
+            "disease_qualifier_names": {
+               "description": "Names of terms from the 'Disease qualifiers' vocabulary",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "disease_relation_name": {
+               "description": "Name of term from 'Disease Relation Vocabulary' vocabulary",
+               "type": "string"
+            },
+            "do_term_curie": {
+               "description": "Curie of DOTerm describing the disease",
+               "type": "string"
+            },
+            "evidence_code_curies": {
+               "description": "List of ECOTerm curies",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "genetic_sex_name": {
+               "description": "Name of term from the 'Genetic sexes' vocabulary",
+               "type": "string"
+            },
+            "inferred_gene_curie": {
+               "description": "Curie of gene to which something is inferred to be associated via an automated pipeline",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "mod_entity_id": {
+               "description": "The model organism database (MOD) identifier/curie for the object",
+               "type": "string"
+            },
+            "negated": {
+               "description": "if set to true, then the association is negated i.e. is not true",
+               "type": "boolean"
+            },
+            "note_dtos": {
+               "items": {
+                  "$ref": "#/$defs/NoteDTO"
+               },
+               "type": "array"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "reference_curie": {
+               "description": "External reference curie used for ingest",
+               "type": "string"
+            },
+            "secondary_data_provider": {
+               "description": "Organization (e.g. MOD) that provided the data directly to the Alliance, but not the original source",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            },
+            "with_gene_curies": {
+               "description": "http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/#with-or-from-column-8",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            }
+         },
+         "required": [
+            "internal",
+            "disease_relation_name",
+            "do_term_curie",
+            "allele_curie"
+         ],
+         "title": "AlleleDiseaseAnnotationDTO",
+         "type": "object"
+      },
+      "AlleleFunctionalImpact": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
-               "type": "string"
-            },
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -1130,7 +2015,7 @@
                },
                "type": "array"
             },
-            "functional_impact": {
+            "functional_impacts": {
                "description": "Experimentally assessed functional impact of the allele, e.g. knockout / amorphic",
                "items": {
                   "type": "string"
@@ -1145,6 +2030,9 @@
                "description": "Entity is no longer current.",
                "type": "boolean"
             },
+            "single_allele": {
+               "type": "string"
+            },
             "updated_by": {
                "description": "The individual that last modified the entity.",
                "type": "string"
@@ -1153,7 +2041,68 @@
          "required": [
             "internal"
          ],
-         "title": "AlleleFunctionalImpactAnnotation",
+         "title": "AlleleFunctionalImpact",
+         "type": "object"
+      },
+      "AlleleFunctionalImpactDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "functional_impact_names": {
+               "description": "Name of the VocabularyTerm describing the functional impact",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleFunctionalImpactDTO",
          "type": "object"
       },
       "AlleleGeneAssociation": {
@@ -1232,6 +2181,80 @@
          "title": "AlleleGeneAssociation",
          "type": "object"
       },
+      "AlleleGeneAssociationDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "allele_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_code_curie": {
+               "description": "Curie of ECOTerm",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "gene_curie": {
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "note_dto": {
+               "$ref": "#/$defs/NoteDTO"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "ro_term_curie": {
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "ro_term_curie",
+            "evidence_curies",
+            "gene_curie"
+         ],
+         "title": "AlleleGeneAssociationDTO",
+         "type": "object"
+      },
       "AlleleGenerationMethodAssociation": {
          "additionalProperties": false,
          "description": "",
@@ -1304,13 +2327,80 @@
          "title": "AlleleGenerationMethodAssociation",
          "type": "object"
       },
-      "AlleleGermlineTransmissionStatusAnnotation": {
+      "AlleleGenerationMethodAssociationDTO": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
+            "allele_curie": {
                "type": "string"
             },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "generation_method_dto": {
+               "$ref": "#/$defs/GenerationMethodDTO"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "mutation_target_strain_curie": {
+               "description": "Curie of the particular strain that is targeted by the generation method for a particular allele (MGI only)",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "predicate_name": {
+               "description": "Name of VocabularyTerm representing predicate of an Association",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "predicate_name"
+         ],
+         "title": "AlleleGenerationMethodAssociationDTO",
+         "type": "object"
+      },
+      "AlleleGermlineTransmissionStatus": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -1353,6 +2443,9 @@
                "description": "Entity is no longer current.",
                "type": "boolean"
             },
+            "single_allele": {
+               "type": "string"
+            },
             "updated_by": {
                "description": "The individual that last modified the entity.",
                "type": "string"
@@ -1361,7 +2454,65 @@
          "required": [
             "internal"
          ],
-         "title": "AlleleGermlineTransmissionStatusAnnotation",
+         "title": "AlleleGermlineTransmissionStatus",
+         "type": "object"
+      },
+      "AlleleGermlineTransmissionStatusDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "germline_transmission_status_name": {
+               "description": "Name of the VocabularyTerm representing the germline transmission status",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleGermlineTransmissionStatusDTO",
          "type": "object"
       },
       "AlleleImageAssociation": {
@@ -1415,7 +2566,7 @@
                "type": "string"
             },
             "primary_image": {
-               "description": "Can be null; if false, maybe you would show all the images. We need to revisit this issue. ",
+               "description": "Can be null; if false, maybe you would show all the images. We need to revisit this issue.",
                "type": "string"
             },
             "subject": {
@@ -1436,13 +2587,74 @@
          "title": "AlleleImageAssociation",
          "type": "object"
       },
-      "AlleleMolecularMutationAnnotation": {
+      "AlleleImageAssociationDTO": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
+            "allele_curie": {
                "type": "string"
             },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "image_curie": {
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "predicate_name": {
+               "description": "Name of VocabularyTerm representing predicate of an Association",
+               "type": "string"
+            },
+            "primary_image": {
+               "description": "The primary image for an allele that is used to represent the allele on a page.",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "predicate_name",
+            "image_curie"
+         ],
+         "title": "AlleleImageAssociationDTO",
+         "type": "object"
+      },
+      "AlleleMolecularMutation": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -1488,6 +2700,9 @@
                "description": "Entity is no longer current.",
                "type": "boolean"
             },
+            "single_allele": {
+               "type": "string"
+            },
             "updated_by": {
                "description": "The individual that last modified the entity.",
                "type": "string"
@@ -1496,16 +2711,74 @@
          "required": [
             "internal"
          ],
-         "title": "AlleleMolecularMutationAnnotation",
+         "title": "AlleleMolecularMutation",
          "type": "object"
       },
-      "AlleleMutationTypeAnnotation": {
+      "AlleleMolecularMutationDTO": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
                "type": "string"
             },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "molecular_mutation_names": {
+               "description": "Name of the VocabularyTerm describing the molecular mutation",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleMolecularMutationDTO",
+         "type": "object"
+      },
+      "AlleleMutationType": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -1540,13 +2813,19 @@
                "description": "Classifies the entity as private (for internal use) or not (for public use).",
                "type": "boolean"
             },
-            "mutation_type": {
+            "mutation_types": {
                "description": "SO term for type of mutation",
-               "type": "string"
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
             },
             "obsolete": {
                "description": "Entity is no longer current.",
                "type": "boolean"
+            },
+            "single_allele": {
+               "type": "string"
             },
             "updated_by": {
                "description": "The individual that last modified the entity.",
@@ -1556,16 +2835,74 @@
          "required": [
             "internal"
          ],
-         "title": "AlleleMutationTypeAnnotation",
+         "title": "AlleleMutationType",
          "type": "object"
       },
-      "AlleleNomenclatureAnnotation": {
+      "AlleleMutationTypeDTO": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
                "type": "string"
             },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "mutation_type_curies": {
+               "description": "Curies of SOTerms representing mutation type",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleMutationTypeDTO",
+         "type": "object"
+      },
+      "AlleleNomenclatureEvent": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -1601,12 +2938,15 @@
                "type": "boolean"
             },
             "nomenclature_event": {
-               "$ref": "#/$defs/NomenclatureEventEnum",
-               "description": "any of the kinds of changes made to an object's name or symbol"
+               "description": "any of the kinds of changes made to an object's name or symbol",
+               "type": "string"
             },
             "obsolete": {
                "description": "Entity is no longer current.",
                "type": "boolean"
+            },
+            "single_allele": {
+               "type": "string"
             },
             "updated_by": {
                "description": "The individual that last modified the entity.",
@@ -1616,12 +2956,70 @@
          "required": [
             "internal"
          ],
-         "title": "AlleleNomenclatureAnnotation",
+         "title": "AlleleNomenclatureEvent",
          "type": "object"
       },
-      "AlleleNotesAssociation": {
+      "AlleleNomenclatureEventDTO": {
          "additionalProperties": false,
-         "description": "The relationship between an allele and a note.",
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "nomenclature_event_name": {
+               "description": "Name of the VocabularyTerm describing the nomenclature event",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleNomenclatureEventDTO",
+         "type": "object"
+      },
+      "AlleleNote": {
+         "additionalProperties": false,
+         "description": "",
          "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
@@ -1657,20 +3055,15 @@
                "description": "Classifies the entity as private (for internal use) or not (for public use).",
                "type": "boolean"
             },
-            "object": {
-               "$ref": "#/$defs/Note",
-               "description": "connects an association to the object of the association. For example, in a gene-to-phenotype association, the gene is subject and phenotype is object."
-            },
             "obsolete": {
                "description": "Entity is no longer current.",
                "type": "boolean"
             },
-            "predicate": {
-               "description": "A high-level grouping for the relationship type. This is analogous to category for nodes. In RDF, this corresponds to rdf:predicate and in Neo4j this corresponds to the relationship type.",
-               "type": "string"
+            "related_note": {
+               "$ref": "#/$defs/Note",
+               "description": "Holds between an object and a Note object."
             },
-            "subject": {
-               "description": "connects an association to the subject of the association. For example, in a gene-to-phenotype association, the gene is subject and phenotype is object.",
+            "single_allele": {
                "type": "string"
             },
             "updated_by": {
@@ -1679,12 +3072,66 @@
             }
          },
          "required": [
-            "internal",
-            "predicate",
-            "subject",
-            "object"
+            "internal"
          ],
-         "title": "AlleleNotesAssociation",
+         "title": "AlleleNote",
+         "type": "object"
+      },
+      "AlleleNoteDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "note_dto": {
+               "$ref": "#/$defs/NoteDTO"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleNoteDTO",
          "type": "object"
       },
       "AlleleOriginAssociation": {
@@ -1755,6 +3202,66 @@
          "title": "AlleleOriginAssociation",
          "type": "object"
       },
+      "AlleleOriginAssociationDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "agm_curie": {
+               "type": "string"
+            },
+            "allele_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "predicate_name": {
+               "description": "Name of VocabularyTerm representing predicate of an Association",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "predicate_name",
+            "agm_curie"
+         ],
+         "title": "AlleleOriginAssociationDTO",
+         "type": "object"
+      },
       "AllelePhenotypeAnnotation": {
          "additionalProperties": false,
          "description": "An annotation asserting an association between an allele and a phenotype supported by evidence.",
@@ -1763,9 +3270,12 @@
                "description": "The allele to which something is manually asserted to be associated.",
                "type": "string"
             },
-            "asserted_gene": {
-               "description": "The gene to which something is manually asserted to be associated.",
-               "type": "string"
+            "asserted_genes": {
+               "description": "The gene(s) to which something is manually asserted to be associated.",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
             },
             "condition_relations": {
                "items": {
@@ -1930,13 +3440,84 @@
          "title": "AlleleProteinAssociation",
          "type": "object"
       },
-      "AlleleSecondaryIdAnnotation": {
+      "AlleleProteinAssociationDTO": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
+            "allele_curie": {
                "type": "string"
             },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_code_curie": {
+               "description": "Curie of ECOTerm",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "note_dto": {
+               "$ref": "#/$defs/NoteDTO"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "protein_curie": {
+               "type": "string"
+            },
+            "ro_term_curie": {
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "ro_term_curie",
+            "evidence_curies",
+            "protein_curie"
+         ],
+         "title": "AlleleProteinAssociationDTO",
+         "type": "object"
+      },
+      "AlleleSecondaryId": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
                "type": "string"
@@ -1978,6 +3559,9 @@
             "secondary_id": {
                "type": "string"
             },
+            "single_allele": {
+               "type": "string"
+            },
             "updated_by": {
                "description": "The individual that last modified the entity.",
                "type": "string"
@@ -1986,18 +3570,15 @@
          "required": [
             "internal"
          ],
-         "title": "AlleleSecondaryIdAnnotation",
+         "title": "AlleleSecondaryId",
          "type": "object"
       },
-      "AlleleSlotAnnotation": {
+      "AlleleSecondaryIdDTO": {
          "additionalProperties": false,
          "description": "",
          "properties": {
-            "allele_id": {
-               "type": "string"
-            },
-            "created_by": {
-               "description": "The individual that created the entity.",
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
                "type": "string"
             },
             "date_created": {
@@ -2020,7 +3601,8 @@
                "format": "date",
                "type": "string"
             },
-            "evidence": {
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
                "items": {
                   "type": "string"
                },
@@ -2034,20 +3616,23 @@
                "description": "Entity is no longer current.",
                "type": "boolean"
             },
-            "updated_by": {
-               "description": "The individual that last modified the entity.",
+            "secondary_id": {
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
                "type": "string"
             }
          },
          "required": [
             "internal"
          ],
-         "title": "AlleleSlotAnnotation",
+         "title": "AlleleSecondaryIdDTO",
          "type": "object"
       },
-      "AlleleSynonymAssociation": {
+      "AlleleSynonym": {
          "additionalProperties": false,
-         "description": "The relationship between an allele and a synonym.",
+         "description": "",
          "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
@@ -2083,25 +3668,20 @@
                "description": "Classifies the entity as private (for internal use) or not (for public use).",
                "type": "boolean"
             },
-            "object": {
-               "$ref": "#/$defs/Synonym",
-               "description": "connects an association to the object of the association. For example, in a gene-to-phenotype association, the gene is subject and phenotype is object."
-            },
             "obsolete": {
                "description": "Entity is no longer current.",
                "type": "boolean"
             },
-            "predicate": {
-               "description": "A high-level grouping for the relationship type. This is analogous to category for nodes. In RDF, this corresponds to rdf:predicate and in Neo4j this corresponds to the relationship type.",
+            "single_allele": {
                "type": "string"
             },
-            "subject": {
-               "description": "connects an association to the subject of the association. For example, in a gene-to-phenotype association, the gene is subject and phenotype is object.",
+            "synonym": {
+               "description": "the text string of the synonym",
                "type": "string"
             },
             "synonym_scope": {
-               "$ref": "#/$defs/SynonymScopeEnum",
-               "description": "the scope of the synonym, e.g. 'EXACT', 'NARROW' or 'RELATED'"
+               "description": "the scope of the synonym - permissible values are narrow / broad / related / exact",
+               "type": "string"
             },
             "updated_by": {
                "description": "The individual that last modified the entity.",
@@ -2109,12 +3689,70 @@
             }
          },
          "required": [
-            "internal",
-            "predicate",
-            "subject",
-            "object"
+            "internal"
          ],
-         "title": "AlleleSynonymAssociation",
+         "title": "AlleleSynonym",
+         "type": "object"
+      },
+      "AlleleSynonymDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "synonym_dto": {
+               "$ref": "#/$defs/SynonymDTO"
+            },
+            "synonym_scope_name": {
+               "description": "Name of the VocabularyTerm representing the scope of the synonym - permissible values are narrow / broad / related / exact",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AlleleSynonymDTO",
          "type": "object"
       },
       "AlleleTranscriptAssociation": {
@@ -2193,6 +3831,80 @@
          "title": "AlleleTranscriptAssociation",
          "type": "object"
       },
+      "AlleleTranscriptAssociationDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "allele_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_code_curie": {
+               "description": "Curie of ECOTerm",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "note_dto": {
+               "$ref": "#/$defs/NoteDTO"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "ro_term_curie": {
+               "type": "string"
+            },
+            "transcript_curie": {
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "ro_term_curie",
+            "evidence_curies",
+            "transcript_curie"
+         ],
+         "title": "AlleleTranscriptAssociationDTO",
+         "type": "object"
+      },
       "AlleleVariantAssociation": {
          "additionalProperties": false,
          "description": "The relationship between an allele and a variant is many to many. An Allele may have many variants and a variant can be present in many alleles.",
@@ -2267,6 +3979,79 @@
             "object"
          ],
          "title": "AlleleVariantAssociation",
+         "type": "object"
+      },
+      "AlleleVariantAssociationDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "allele_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_code_curie": {
+               "description": "Curie of ECOTerm",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "note_dto": {
+               "$ref": "#/$defs/NoteDTO"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "ro_term_curie": {
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            },
+            "variant_curie": {
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "allele_curie",
+            "ro_term_curie",
+            "evidence_curies"
+         ],
+         "title": "AlleleVariantAssociationDTO",
          "type": "object"
       },
       "AnatomicalSite": {
@@ -2534,7 +4319,7 @@
       },
       "Association": {
          "additionalProperties": false,
-         "description": "A typed association between two entities, supported by evidence.  Associations have three base slots: subject,  object, and predicate, but they can have any number of additional attributes that help qualify the relationship  between the subject and the object.  The subject is the curie (or identifier) of the class that is the subject  of the association, and likewise the object is the curie (or identifier of the class that is the object. The  relationship between subject and object is defined by the predicate slot (which can also be constrained  using the range of the predicate).",
+         "description": "A typed association between two entities, supported by evidence.  Associations have three base slots: subject, object, and predicate, but they can have any number of additional attributes that help qualify the relationship between the subject and the object.  The subject is the curie (or identifier) of the class that is the subject of the association, and likewise the object is the curie (or identifier of the class that is the object. The relationship between subject and object is defined by the predicate slot (which can also be constrained using the range of the predicate).",
          "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
@@ -2645,6 +4430,53 @@
             "internal"
          ],
          "title": "AuditedObject",
+         "type": "object"
+      },
+      "AuditedObjectDTO": {
+         "additionalProperties": false,
+         "description": "Base class for all other LinkML DTO classes.",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "AuditedObjectDTO",
          "type": "object"
       },
       "AuthorReference": {
@@ -3227,6 +5059,73 @@
          "title": "ConditionRelation",
          "type": "object"
       },
+      "ConditionRelationDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for the pairing of an experimental condition relation with a list of one or more conditions",
+         "properties": {
+            "condition_dtos": {
+               "items": {
+                  "$ref": "#/$defs/ExperimentalConditionDTO"
+               },
+               "type": "array"
+            },
+            "condition_relation_type_name": {
+               "description": "Name of VocabularyTerm from 'Condition relation types' vocabulary",
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "handle": {
+               "description": "A slot pointing to a free-text alias or 'handle' for a data object, such as a reference-specific alias for a data object used while curating.",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "reference_curie": {
+               "description": "External reference curie used for ingest",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "condition_relation_type_name",
+            "condition_dtos"
+         ],
+         "title": "ConditionRelationDTO",
+         "type": "object"
+      },
       "Construct": {
          "additionalProperties": false,
          "description": "",
@@ -3563,6 +5462,74 @@
             "prefix"
          ],
          "title": "CrossReference",
+         "type": "object"
+      },
+      "CrossReferenceDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "curie": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "display_name": {
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "page_areas": {
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "prefix": {
+               "description": "Denormalization to help with classifying types of crossReferences, distinguishing DOIs from PMC ids, etc.",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "curie",
+            "page_areas",
+            "display_name",
+            "prefix"
+         ],
+         "title": "CrossReferenceDTO",
          "type": "object"
       },
       "DAOTerm": {
@@ -4422,12 +6389,8 @@
                "description": "Optional free text field that records the units/amount/degrees of a condition.",
                "type": "string"
             },
-            "condition_statement": {
-               "description": "Free text describing the environmental/experimental condition. For some groups this is a single term, others is it is a concatenation of the term names from the ontologies included in this data structure. To be submitted by DQMs; eventually will be deprecated once DQMs no longer submit these ExperimentalCondition objects.",
-               "type": "string"
-            },
             "condition_summary": {
-               "description": "Free text describing the environmental/experimental condition. For some groups this is a single term, others is it is a concatenation of the term names from the ontologies included in this data structure. Similar to condition_statement except the condition_summary will not be submitted by DQMs but rather generated at the Alliance after ingest (or generated/updated in the curation interface and persistent store).",
+               "description": "Free text describing the environmental/experimental condition. For some groups this is a single term, others is it is a concatenation of the term names from the ontologies included in this data structure. The condition_summary will not be submitted by DQMs but rather generated at the Alliance after ingest (or generated/updated in the curation interface and persistent store).",
                "type": "string"
             },
             "condition_taxon": {
@@ -4477,10 +6440,88 @@
          },
          "required": [
             "internal",
-            "condition_class",
-            "condition_statement"
+            "condition_class"
          ],
          "title": "ExperimentalCondition",
+         "type": "object"
+      },
+      "ExperimentalConditionDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for describing the environmental context in which an experiment is carried out",
+         "properties": {
+            "condition_anatomy_curie": {
+               "description": "Curie of AnatomicalTerm associated with condition",
+               "type": "string"
+            },
+            "condition_chemical_curie": {
+               "description": "Curie of ChemicalTerm associated with condition",
+               "type": "string"
+            },
+            "condition_class_curie": {
+               "description": "Curie of ZECOTerm describing condition class",
+               "type": "string"
+            },
+            "condition_free_text": {
+               "description": "Free-text description of the experimental condition",
+               "type": "string"
+            },
+            "condition_gene_ontology_curie": {
+               "description": "Curie of GOTerm associated with condition",
+               "type": "string"
+            },
+            "condition_id_curie": {
+               "description": "Curie of ExperimentalConditionOntologyTerm describing condition",
+               "type": "string"
+            },
+            "condition_quantity": {
+               "type": "string"
+            },
+            "condition_taxon_curie": {
+               "description": "Curie of NCBITaxonTerm associated with condition",
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "condition_class_curie"
+         ],
+         "title": "ExperimentalConditionDTO",
          "type": "object"
       },
       "ExpressionAnnotation": {
@@ -5691,14 +7732,103 @@
          "title": "GeneCollection",
          "type": "object"
       },
+      "GeneDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for genes",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "cross_reference_dtos": {
+               "items": {
+                  "$ref": "#/$defs/CrossReferenceDTO"
+               },
+               "type": "array"
+            },
+            "curie": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "gene_type_curie": {
+               "description": "Curie of SOTerm describing gene type",
+               "type": "string"
+            },
+            "genomic_location_dtos": {
+               "items": {
+                  "$ref": "#/$defs/GenomicLocationDTO"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "name": {
+               "description": "a human-readable name for an entity",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "secondary_identifiers": {
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "symbol": {
+               "description": "Symbol for a particular thing",
+               "type": "string"
+            },
+            "synonym_dtos": {
+               "items": {
+                  "$ref": "#/$defs/SynonymDTO"
+               },
+               "type": "array"
+            },
+            "taxon_curie": {
+               "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "curie",
+            "taxon_curie"
+         ],
+         "title": "GeneDTO",
+         "type": "object"
+      },
       "GeneDiseaseAnnotation": {
          "additionalProperties": false,
          "description": "An annotation asserting an association between a gene and a disease supported by evidence.",
          "properties": {
-            "alliance_curie": {
-               "description": "The Alliance-minted ID for the disease annotation. The ID is of the format AGRKB:100000000000001, where the first three digits represent the DiseaseAnnotation class code of \"100\", followed by a 12-digit identifier",
-               "type": "string"
-            },
             "annotation_type": {
                "description": "The type of annotation classified according to curation method. Submitted value should be a vocabulary term from the 'Annotation types' vocabulary",
                "type": "string"
@@ -5711,6 +7841,10 @@
             },
             "created_by": {
                "description": "The individual that created the entity.",
+               "type": "string"
+            },
+            "curie": {
+               "description": "The Alliance-minted ID for the disease annotation. The ID is of the format AGRKB:100000000000001, where the first three digits represent the DiseaseAnnotation class code of \"100\", followed by a 12-digit identifier",
                "type": "string"
             },
             "data_provider": {
@@ -5833,6 +7967,7 @@
          },
          "required": [
             "internal",
+            "curie",
             "evidence_codes",
             "single_reference",
             "data_provider",
@@ -5841,6 +7976,147 @@
             "predicate"
          ],
          "title": "GeneDiseaseAnnotation",
+         "type": "object"
+      },
+      "GeneDiseaseAnnotationDTO": {
+         "additionalProperties": false,
+         "description": "Ingest class for an association between a gene and a disease",
+         "properties": {
+            "annotation_type_name": {
+               "description": "Name of the VocabularyTerm describing the annotation type",
+               "type": "string"
+            },
+            "condition_relation_dtos": {
+               "items": {
+                  "$ref": "#/$defs/ConditionRelationDTO"
+               },
+               "type": "array"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "data_provider": {
+               "description": "Organization (e.g. MOD) from which the data was sourced",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "disease_genetic_modifier_curie": {
+               "description": "Curie of BiologcalEntity that modifies the disease model",
+               "type": "string"
+            },
+            "disease_genetic_modifier_relation_name": {
+               "description": "Name of the VocabularyTerm from the 'Disease genetic modifiers' vocabulary that describes how the genetic modifier modifies the disease model.",
+               "type": "string"
+            },
+            "disease_qualifier_names": {
+               "description": "Names of terms from the 'Disease qualifiers' vocabulary",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "disease_relation_name": {
+               "description": "Name of term from 'Disease Relation Vocabulary' vocabulary",
+               "type": "string"
+            },
+            "do_term_curie": {
+               "description": "Curie of DOTerm describing the disease",
+               "type": "string"
+            },
+            "evidence_code_curies": {
+               "description": "List of ECOTerm curies",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "gene_curie": {
+               "type": "string"
+            },
+            "genetic_sex_name": {
+               "description": "Name of term from the 'Genetic sexes' vocabulary",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "mod_entity_id": {
+               "description": "The model organism database (MOD) identifier/curie for the object",
+               "type": "string"
+            },
+            "negated": {
+               "description": "if set to true, then the association is negated i.e. is not true",
+               "type": "boolean"
+            },
+            "note_dtos": {
+               "items": {
+                  "$ref": "#/$defs/NoteDTO"
+               },
+               "type": "array"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "reference_curie": {
+               "description": "External reference curie used for ingest",
+               "type": "string"
+            },
+            "secondary_data_provider": {
+               "description": "Organization (e.g. MOD) that provided the data directly to the Alliance, but not the original source",
+               "type": "string"
+            },
+            "sgd_strain_background_curie": {
+               "description": "Curie of SGD strain background AGM",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            },
+            "with_gene_curies": {
+               "description": "http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/#with-or-from-column-8",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            }
+         },
+         "required": [
+            "internal",
+            "disease_relation_name",
+            "do_term_curie",
+            "gene_curie"
+         ],
+         "title": "GeneDiseaseAnnotationDTO",
          "type": "object"
       },
       "GeneGeneticInteraction": {
@@ -6424,11 +8700,11 @@
          "description": "",
          "properties": {
             "['mutagee']": {
-               "description": "The target of the mutation, e.g. strain / adult females /  adult males / embryos / sperm / not specified",
+               "description": "The target of the mutation, e.g. strain / adult females / adult males / embryos / sperm / not specified",
                "type": "string"
             },
             "['mutagen']": {
-               "description": "Technique used to create the allele, e.g. spontaneous / naturally occurring / radiation-induced / recombinant /  ENU / CRISPR / TALEN / gamma rays / not specified / spontaneous / DNA / DNA AND CRISPR / DNA and TALEN / zinc finger nuclease / EMS",
+               "description": "Technique used to create the allele, e.g. spontaneous / naturally occurring / radiation-induced / recombinant / ENU / CRISPR / TALEN / gamma rays / not specified / spontaneous / DNA / DNA AND CRISPR / DNA and TALEN / zinc finger nuclease / EMS",
                "type": "string"
             },
             "created_by": {
@@ -6472,6 +8748,61 @@
             "internal"
          ],
          "title": "GenerationMethod",
+         "type": "object"
+      },
+      "GenerationMethodDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "['mutagee']": {
+               "description": "The target of the mutation, e.g. strain / adult females / adult males / embryos / sperm / not specified",
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "mutagenesis_method_name": {
+               "description": "Name of the VocabularyTerm describing the mutagenesis method, e.g. spontaneous / naturally occurring / radiation-induced / recombinant / ENU / CRISPR / TALEN / gamma rays / not specified / spontaneous / DNA / DNA AND CRISPR / DNA and TALEN / zinc finger nuclease / EMS",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "GenerationMethodDTO",
          "type": "object"
       },
       "GeneticMapPosition": {
@@ -6677,6 +9008,91 @@
          "title": "GenomicEntity",
          "type": "object"
       },
+      "GenomicEntityDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "cross_reference_dtos": {
+               "items": {
+                  "$ref": "#/$defs/CrossReferenceDTO"
+               },
+               "type": "array"
+            },
+            "curie": {
+               "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "genomic_location_dtos": {
+               "items": {
+                  "$ref": "#/$defs/GenomicLocationDTO"
+               },
+               "type": "array"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "name": {
+               "description": "a human-readable name for an entity",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "secondary_identifiers": {
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "synonym_dtos": {
+               "items": {
+                  "$ref": "#/$defs/SynonymDTO"
+               },
+               "type": "array"
+            },
+            "taxon_curie": {
+               "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "curie",
+            "taxon_curie"
+         ],
+         "title": "GenomicEntityDTO",
+         "type": "object"
+      },
       "GenomicLocation": {
          "additionalProperties": false,
          "description": "",
@@ -6749,6 +9165,80 @@
             "has_assembly"
          ],
          "title": "GenomicLocation",
+         "type": "object"
+      },
+      "GenomicLocationDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "assembly_curie": {
+               "type": "string"
+            },
+            "chromosome_curie": {
+               "type": "string"
+            },
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "end": {
+               "description": "The end of the feature in positive 1-based integer coordinates",
+               "type": "string"
+            },
+            "genomic_entity_curie": {
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "predicate": {
+               "description": "A high-level grouping for the relationship type. This is analogous to category for nodes. In RDF, this corresponds to rdf:predicate and in Neo4j this corresponds to the relationship type.",
+               "type": "string"
+            },
+            "start": {
+               "description": "The start of the feature in positive 1-based integer coordinates",
+               "type": "string"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "genomic_entity_curie",
+            "predicate",
+            "chromosome_curie",
+            "assembly_curie",
+            "start",
+            "end"
+         ],
+         "title": "GenomicLocationDTO",
          "type": "object"
       },
       "HeavyChainIsotypeSet": {
@@ -7057,127 +9547,79 @@
          "properties": {
             "agm_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AffectedGenomicModel"
+                  "$ref": "#/$defs/AffectedGenomicModelDTO"
                },
                "type": "array"
             },
             "allele_cell_line_association_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleCellLineAssociation"
+                  "$ref": "#/$defs/AlleleCellLineAssociationDTO"
                },
                "type": "array"
             },
             "allele_construct_association_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleConstructAssociation"
-               },
-               "type": "array"
-            },
-            "allele_database_status_annotation_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/AlleleDatabaseStatusAnnotation"
-               },
-               "type": "array"
-            },
-            "allele_functional_impact_annotation_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/AlleleFunctionalImpactAnnotation"
+                  "$ref": "#/$defs/AlleleConstructAssociationDTO"
                },
                "type": "array"
             },
             "allele_gene_association_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleGeneAssociation"
-               },
-               "type": "array"
-            },
-            "allele_generation_method_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/GenerationMethod"
-               },
-               "type": "array"
-            },
-            "allele_germline_transmission_status_annotation_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/AlleleGermlineTransmissionStatusAnnotation"
+                  "$ref": "#/$defs/AlleleGeneAssociationDTO"
                },
                "type": "array"
             },
             "allele_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/Allele"
-               },
-               "type": "array"
-            },
-            "allele_molecular_mutation_annotation_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/AlleleMolecularMutationAnnotation"
-               },
-               "type": "array"
-            },
-            "allele_mutation_type_annotation_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/AlleleMutationTypeAnnotation"
-               },
-               "type": "array"
-            },
-            "allele_nomenclature_annotation_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/AlleleNomenclatureAnnotation"
+                  "$ref": "#/$defs/AlleleDTO"
                },
                "type": "array"
             },
             "allele_origin_association_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleOriginAssociation"
+                  "$ref": "#/$defs/AlleleOriginAssociationDTO"
                },
                "type": "array"
             },
             "allele_protein_association_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleProteinAssociation"
-               },
-               "type": "array"
-            },
-            "allele_secondary_id_annotation_ingest_set": {
-               "items": {
-                  "$ref": "#/$defs/AlleleSecondaryIdAnnotation"
+                  "$ref": "#/$defs/AlleleProteinAssociationDTO"
                },
                "type": "array"
             },
             "allele_transcript_association_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleTranscriptAssociation"
+                  "$ref": "#/$defs/AlleleTranscriptAssociationDTO"
                },
                "type": "array"
             },
             "allele_variant_association_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleVariantAssociation"
+                  "$ref": "#/$defs/AlleleVariantAssociationDTO"
                },
                "type": "array"
             },
             "disease_agm_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AGMDiseaseAnnotation"
+                  "$ref": "#/$defs/AGMDiseaseAnnotationDTO"
                },
                "type": "array"
             },
             "disease_allele_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/AlleleDiseaseAnnotation"
+                  "$ref": "#/$defs/AlleleDiseaseAnnotationDTO"
                },
                "type": "array"
             },
             "disease_gene_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/GeneDiseaseAnnotation"
+                  "$ref": "#/$defs/GeneDiseaseAnnotationDTO"
                },
                "type": "array"
             },
             "gene_ingest_set": {
                "items": {
-                  "$ref": "#/$defs/Gene"
+                  "$ref": "#/$defs/GeneDTO"
                },
                "type": "array"
             },
@@ -8448,15 +10890,6 @@
          "title": "NCBITaxonTerm",
          "type": "object"
       },
-      "NomenclatureEventEnum": {
-         "description": "",
-         "enum": [
-            "named",
-            "renamed"
-         ],
-         "title": "NomenclatureEventEnum",
-         "type": "string"
-      },
       "Note": {
          "additionalProperties": false,
          "description": "Note object for capturing free-text describing some attribute of an entity, coupled with a 'note type', internal boolean, and an optional list of references. Permissible values for note_type can be viewed and managed in the A-Team curation UI Controlled Vocabulary Terms Table.",
@@ -8518,6 +10951,69 @@
             "note_type"
          ],
          "title": "Note",
+         "type": "object"
+      },
+      "NoteDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "evidence_curies": {
+               "description": "Curies of InformationContentEntity objects given as evidence",
+               "items": {
+                  "type": "string"
+               },
+               "type": "array"
+            },
+            "free_text": {
+               "description": "A free text string that describes some aspect of an entity.",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "note_type_name": {
+               "description": "Name of VocabularyTerm representing note type",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal",
+            "free_text"
+         ],
+         "title": "NoteDTO",
          "type": "object"
       },
       "OntologyTerm": {
@@ -8666,7 +11162,7 @@
                "type": "string"
             },
             "distance_between": {
-               "description": "distance_between is zero for reflexive\u2013transitive closure each node has an ancestor or descendant of itself ",
+               "description": "distance_between is zero for reflexive\u2013transitive closure each node has an ancestor or descendant of itself",
                "type": "integer"
             },
             "internal": {
@@ -9741,7 +12237,7 @@
                "type": "string"
             },
             "authors": {
-               "description": "Ordered author entities for this publication.  An Author is associated with only one publication.  A Person can be associated with multiple  publications.",
+               "description": "Ordered author entities for this publication.  An Author is associated with only one publication.  A Person can be associated with multiple publications.",
                "items": {
                   "$ref": "#/$defs/AuthorReference"
                },
@@ -9907,7 +12403,7 @@
          "description": "",
          "properties": {
             "authors": {
-               "description": "Ordered author entities for this publication.  An Author is associated with only one publication.  A Person can be associated with multiple  publications.",
+               "description": "Ordered author entities for this publication.  An Author is associated with only one publication.  A Person can be associated with multiple publications.",
                "items": {
                   "$ref": "#/$defs/AuthorReference"
                },
@@ -10308,7 +12804,7 @@
       },
       "SlotAnnotation": {
          "additionalProperties": false,
-         "description": "SlotAnnotation classes should be used when we need to attach metadata (in particular evidence and provenance) to a slot in the context of its referencing class, that can not be fully captured using an Association between the full class itself, and an InformationContentEntity. Evidence and provenance can exist here in the form of an evidence code, a publication, a personal communication or any other kind of InformationContentEntity. SlotAnnotation classes are used where the slot is not referencing a class in and of itself, and often has a  scalar range.",
+         "description": "SlotAnnotation classes should be used when we need to attach metadata (in particular evidence and provenance) to a slot in the context of its referencing class, that can not be fully captured using an Association between the full class itself, and an InformationContentEntity. Evidence and provenance can exist here in the form of an evidence code, a publication, a personal communication or any other kind of InformationContentEntity. SlotAnnotation classes are used where the slot is not referencing a class in and of itself, and often has a scalar range.",
          "properties": {
             "created_by": {
                "description": "The individual that created the entity.",
@@ -10501,6 +12997,57 @@
             "internal"
          ],
          "title": "Synonym",
+         "type": "object"
+      },
+      "SynonymDTO": {
+         "additionalProperties": false,
+         "description": "",
+         "properties": {
+            "created_by_curie": {
+               "description": "Curie of the Person object representing the individual that created the entity",
+               "type": "string"
+            },
+            "date_created": {
+               "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+               "format": "date",
+               "type": "string"
+            },
+            "date_updated": {
+               "description": "Date on which an entity was last modified.",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_created": {
+               "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+               "format": "date",
+               "type": "string"
+            },
+            "db_date_updated": {
+               "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+               "format": "date",
+               "type": "string"
+            },
+            "internal": {
+               "description": "Classifies the entity as private (for internal use) or not (for public use).",
+               "type": "boolean"
+            },
+            "name": {
+               "description": "a human-readable name for an entity",
+               "type": "string"
+            },
+            "obsolete": {
+               "description": "Entity is no longer current.",
+               "type": "boolean"
+            },
+            "updated_by_curie": {
+               "description": "Curie of the Person object representing the individual that updated the entity",
+               "type": "string"
+            }
+         },
+         "required": [
+            "internal"
+         ],
+         "title": "SynonymDTO",
          "type": "object"
       },
       "SynonymScopeEnum": {
@@ -12861,127 +15408,79 @@
    "properties": {
       "agm_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AffectedGenomicModel"
+            "$ref": "#/$defs/AffectedGenomicModelDTO"
          },
          "type": "array"
       },
       "allele_cell_line_association_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleCellLineAssociation"
+            "$ref": "#/$defs/AlleleCellLineAssociationDTO"
          },
          "type": "array"
       },
       "allele_construct_association_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleConstructAssociation"
-         },
-         "type": "array"
-      },
-      "allele_database_status_annotation_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/AlleleDatabaseStatusAnnotation"
-         },
-         "type": "array"
-      },
-      "allele_functional_impact_annotation_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/AlleleFunctionalImpactAnnotation"
+            "$ref": "#/$defs/AlleleConstructAssociationDTO"
          },
          "type": "array"
       },
       "allele_gene_association_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleGeneAssociation"
-         },
-         "type": "array"
-      },
-      "allele_generation_method_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/GenerationMethod"
-         },
-         "type": "array"
-      },
-      "allele_germline_transmission_status_annotation_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/AlleleGermlineTransmissionStatusAnnotation"
+            "$ref": "#/$defs/AlleleGeneAssociationDTO"
          },
          "type": "array"
       },
       "allele_ingest_set": {
          "items": {
-            "$ref": "#/$defs/Allele"
-         },
-         "type": "array"
-      },
-      "allele_molecular_mutation_annotation_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/AlleleMolecularMutationAnnotation"
-         },
-         "type": "array"
-      },
-      "allele_mutation_type_annotation_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/AlleleMutationTypeAnnotation"
-         },
-         "type": "array"
-      },
-      "allele_nomenclature_annotation_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/AlleleNomenclatureAnnotation"
+            "$ref": "#/$defs/AlleleDTO"
          },
          "type": "array"
       },
       "allele_origin_association_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleOriginAssociation"
+            "$ref": "#/$defs/AlleleOriginAssociationDTO"
          },
          "type": "array"
       },
       "allele_protein_association_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleProteinAssociation"
-         },
-         "type": "array"
-      },
-      "allele_secondary_id_annotation_ingest_set": {
-         "items": {
-            "$ref": "#/$defs/AlleleSecondaryIdAnnotation"
+            "$ref": "#/$defs/AlleleProteinAssociationDTO"
          },
          "type": "array"
       },
       "allele_transcript_association_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleTranscriptAssociation"
+            "$ref": "#/$defs/AlleleTranscriptAssociationDTO"
          },
          "type": "array"
       },
       "allele_variant_association_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleVariantAssociation"
+            "$ref": "#/$defs/AlleleVariantAssociationDTO"
          },
          "type": "array"
       },
       "disease_agm_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AGMDiseaseAnnotation"
+            "$ref": "#/$defs/AGMDiseaseAnnotationDTO"
          },
          "type": "array"
       },
       "disease_allele_ingest_set": {
          "items": {
-            "$ref": "#/$defs/AlleleDiseaseAnnotation"
+            "$ref": "#/$defs/AlleleDiseaseAnnotationDTO"
          },
          "type": "array"
       },
       "disease_gene_ingest_set": {
          "items": {
-            "$ref": "#/$defs/GeneDiseaseAnnotation"
+            "$ref": "#/$defs/GeneDiseaseAnnotationDTO"
          },
          "type": "array"
       },
       "gene_ingest_set": {
          "items": {
-            "$ref": "#/$defs/Gene"
+            "$ref": "#/$defs/GeneDTO"
          },
          "type": "array"
       },

--- a/model/schema/affectedGenomicModel.yaml
+++ b/model/schema/affectedGenomicModel.yaml
@@ -47,13 +47,30 @@ classes:
       - data_provider
       - references
 
+  AffectedGenomicModelDTO:
+    is_a: GenomicEntityDTO
+    description: Ingest class for AGMs
+    slots:
+      - subtype_name
+      - reference_curies
+      - data_provider
+      - reference_curies
+      - sequence_targeting_reagent_curies
+      - component_dtos
+
   AffectedGenomicModelComponent:
     is_a: AuditedObject
     description: >-
       Allele that affects the model and its zygosity
     slots:
-      - has_allele
+      - single_allele
       - zygosity
+
+  AffectedGenomicModelComponentDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - allele_curie
+      - zygosity_curie
 
 slots:
 
@@ -63,10 +80,18 @@ slots:
 
   subtype:
     description: >-
-      Subtype of affected genomic model
+      Subtype of affected genomic model - permissible values: strain / genotype
+      / fish
     domain: AffectedGenomicModel
-    range: subtype_values
+    range: VocabularyTerm
     required: true
+
+  subtype_name:
+    description: >-
+      Name of VocabularyTerm describing subtype - permissible values: strain / genotype
+      / fish
+    domain: AffectedGenomicModelDTO
+    range: string
 
   components:
     singular_name: component
@@ -75,6 +100,11 @@ slots:
       i.e. 'allele', each with a zygosity
     domain: AffectedGenomicModel
     range: AffectedGenomicModelComponent
+    multivalued: true
+
+  component_dtos:
+    domain: AffectedGenomicModelDTO
+    range: AffectedGenomicModelComponentDTO
     multivalued: true
 
   has_allele:
@@ -87,10 +117,24 @@ slots:
     domain: AffectedGenomicModelComponent
     range: zygosity_values
 
+  zygosity_curie:
+    description: >-
+      Curie of GENO ontology ID for allele zygosity - permissible_values:
+      GENO:0000602 / GENO:0000603 / GENO:0000604 / GENO:0000605
+      / GENO:0000606 / GENO:0000135 / GENO:0000136 / GENO:0000137
+      / GENO:0000134
+    domain: AffectedGenomicModelComponentDTO
+    range: string
+
   sequence_targeting_reagents:
     singular_name: sequence_targeting_reagent
     domain: AffectedGenomicModel
     range: SequenceTargetingReagent
+    multivalued: true
+
+  sequence_targeting_reagent_curies:
+    domain: AffectedGenomicModelDTO
+    range: string
     multivalued: true
 
   parental_populations:

--- a/model/schema/affectedGenomicModel.yaml
+++ b/model/schema/affectedGenomicModel.yaml
@@ -57,6 +57,10 @@ classes:
 
 slots:
 
+  agm_curie:
+    range: string
+    required: true
+
   subtype:
     description: >-
       Subtype of affected genomic model

--- a/model/schema/affectedGenomicModel.yaml
+++ b/model/schema/affectedGenomicModel.yaml
@@ -54,7 +54,6 @@ classes:
       - subtype_name
       - reference_curies
       - data_provider
-      - reference_curies
       - sequence_targeting_reagent_curies
       - component_dtos
 

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -63,6 +63,14 @@ classes:
       - allele_nomenclature_events
       - allele_notes
       - allele_synonyms
+      - allele_gene_associations
+      - allele_transcript_associations
+      - allele_protein_associations
+      - allele_variant_associations
+      - allele_construct_associations
+      - allele_cell_line_associations
+      - allele_image_associations
+      - allele_origin_associations
     exact_mappings:
       - SO:0001023
     slot_usage:
@@ -106,124 +114,106 @@ classes:
       - mutagenesis_method_name
       - mutagenesis_target
 
-  AlleleMutationType:
-    is_a: AuditedObject
+  AlleleMutationTypeSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - mutation_types
-      - evidence
 
-  AlleleMutationTypeDTO:
-    is_a: AuditedObjectDTO
+  AlleleMutationTypeSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - mutation_type_curies
-      - evidence_curies
 
-  AlleleGermlineTransmissionStatus:
-    is_a: AuditedObject
+  AlleleGermlineTransmissionStatusSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - germline_transmission_status
-      - evidence
 
-  AlleleGermlineTransmissionStatusDTO:
-    is_a: AuditedObjectDTO
+  AlleleGermlineTransmissionStatusSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - germline_transmission_status_name
-      - evidence_curies
 
-  AlleleFunctionalImpact:
-    is_a: AuditedObject
+  AlleleFunctionalImpactSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - functional_impacts
-      - evidence
 
-  AlleleFunctionalImpactDTO:
-    is_a: AuditedObjectDTO
+  AlleleFunctionalImpactSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - functional_impact_names
-      - evidence_curies
 
-  AlleleMolecularMutation:
-    is_a: AuditedObject
+  AlleleMolecularMutationSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - molecular_mutations
-      - evidence
 
-  AlleleMolecularMutationDTO:
-    is_a: AuditedObjectDTO
+  AlleleMolecularMutationSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - molecular_mutation_names
-      - evidence_curies
 
-  AlleleDatabaseStatus:
-    is_a: AuditedObject
+  AlleleDatabaseStatusSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - database_status
-      - evidence
 
-  AlleleDatabaseStatusDTO:
-    is_a: AuditedObject
+  AlleleDatabaseStatusSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - database_status_name
-      - evidence_curies
 
-  AlleleSecondaryId:
-    is_a: AuditedObject
+  AlleleSecondaryIdSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - secondary_id
-      - evidence
 
-  AlleleSecondaryIdDTO:
-    is_a: AuditedObjectDTO
+  AlleleSecondaryIdSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - secondary_id
-      - evidence_curies
 
-  AlleleNomenclatureEvent:
-    is_a: AuditedObject
+  AlleleNomenclatureEventSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - nomenclature_event
-      - evidence
 
-  AlleleNomenclatureEventDTO:
-    is_a: AuditedObjectDTO
+  AlleleNomenclatureEventSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - nomenclature_event_name
-      - evidence_curies
 
-  AlleleNote:
-    is_a: AuditedObject
+  AlleleNoteSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - related_note
-      - evidence
 
-  AlleleNoteDTO:
-    is_a: AuditedObjectDTO
+  AlleleNoteSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - note_dto
-      - evidence_curies
 
-  AlleleSynonym:
-    is_a: AuditedObject
+  AlleleSynonymSlotAnnotation:
+    is_a: SlotAnnotation
     slots:
       - single_allele
       - synonym
       - synonym_scope
-      - evidence
 
-  AlleleSynonymDTO:
-    is_a: AuditedObjectDTO
+  AlleleSynonymSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
     slots:
       - synonym_dto
       - synonym_scope_name
-      - evidence_curies
 
 # Allele Associations
 
@@ -559,20 +549,20 @@ slots:
   allele_molecular_mutations:
     description: Molecular mutations of a given allele
     domain: Allele
-    range: AlleleMolecularMutation
+    range: AlleleMolecularMutationSlotAnnotation
     multivalued: true
 
   molecular_mutations:
     description: >-
       Description of the DNA changes if precise
       genomic location unknown
-    domain: AlleleMolecularMutation
+    domain: AlleleMolecularMutationSlotAnnotation
     range: string
     multivalued: true
 
   allele_molecular_mutation_dtos:
     domain: AlleleDTO
-    range: AlleleMolecularMutationDTO
+    range: AlleleMolecularMutationSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true
@@ -580,44 +570,44 @@ slots:
   molecular_mutation_names:
     description: >-
       Name of the VocabularyTerm describing the molecular mutation
-    domain: AlleleMolecularMutationDTO
+    domain: AlleleMolecularMutationSlotAnnotationDTO
     range: string
     multivalued: true
 
   allele_mutation_types:
     description: Mutation types for a given allele
     domain: Allele
-    range: AlleleMutationType
+    range: AlleleMutationTypeSlotAnnotation
     multivalued: true
 
   allele_mutation_type_dtos:
     domain: AlleleDTO
-    range: AlleleMutationTypeDTO
+    range: AlleleMutationTypeSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true
 
   mutation_types:
     description: SO term for type of mutation
-    domain: AlleleMutationType
+    domain: AlleleMutationTypeSlotAnnotation
     range: SOTerm
     multivalued: true
 
   mutation_type_curies:
     description: Curies of SOTerms representing mutation type
-    domain: AlleleMutationTypeDTO
+    domain: AlleleMutationTypeSlotAnnotationDTO
     range: string
     multivalued: true
 
   allele_functional_impacts:
     description: Functional impacts of a given allele
     domain: Allele
-    range: AlleleFunctionalImpact
+    range: AlleleFunctionalImpactSlotAnnotation
     multivalued: true
 
   allele_functional_impact_dtos:
     domain: AlleleDTO
-    range: AlleleFunctionalImpactDTO
+    range: AlleleFunctionalImpactSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true
@@ -626,61 +616,61 @@ slots:
     description: >-
       Experimentally assessed functional impact of the
       allele, e.g. knockout / amorphic
-    domain: AlleleFunctionalImpact
+    domain: AlleleFunctionalImpactSlotAnnotation
     range: VocabularyTerm
     multivalued: true
 
   functional_impact_names:
     description: >-
       Name of the VocabularyTerm describing the functional impact
-    domain: AlleleFunctionalImpactDTO
+    domain: AlleleFunctionalImpactSlotAnnotationDTO
     range: string
     multivalued: true
 
   allele_germline_transmission_status:
     description: Germline transmission status for a given allele
     domain: Allele
-    range: AlleleGermlineTransmissionStatus
+    range: AlleleGermlineTransmissionStatusSlotAnnotation
 
   allele_germline_transmission_status_dto:
     domain: AlleleDTO
-    range: AlleleGermlineTransmissionStatusDTO
+    range: AlleleGermlineTransmissionStatusSlotAnnotationDTO
     inlined: true
 
   germline_transmission_status:
     description: >-
       For alleles made in cell lines, have they been
       transmitted to the germline of an animal
-    domain: AlleleGermlineTransmissionStatus
+    domain: AlleleGermlineTransmissionStatusSlotAnnotation
     range: VocabularyTerm
 
   germline_transmission_status_name:
     description: >-
       Name of the VocabularyTerm representing the germline transmission
       status
-    domain: AlleleGermlineTransmissionStatusDTO
+    domain: AlleleGermlineTransmissionStatusSlotAnnotationDTO
     range: string
 
   allele_database_status:
     description: Database status of a given allele
     domain: Allele
-    range: AlleleDatabaseStatus
+    range: AlleleDatabaseStatusSlotAnnotation
 
   allele_database_status_dto:
     domain: AlleleDTO
-    range: AlleleDatabaseStatusDTO
+    range: AlleleDatabaseStatusSlotAnnotationDTO
     inlined: true
 
   database_status:
     description: >-
       Database status of the allele
-    domain: AlleleDatabaseStatus
+    domain: AlleleDatabaseStatusSlotAnnotation
     range: VocabularyTerm
 
   database_status_name:
     description: >-
       Name of the VocabularyTerm describing the database status
-    domain: AlleleDatabaseStatusDTO
+    domain: AlleleDatabaseStatusSlotAnnotationDTO
     range: string
 
   inheritance_mode:
@@ -752,12 +742,12 @@ slots:
   allele_nomenclature_events:
     description: Nomenclature events of a given allele
     domain: Allele
-    range: AlleleNomenclatureEvent
+    range: AlleleNomenclatureEventSlotAnnotation
     multivalued: true
 
   allele_nomenclature_event_dtos:
     domain: AlleleDTO
-    range: AlleleNomenclatureEventDTO
+    range: AlleleNomenclatureEventSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true
@@ -767,24 +757,24 @@ slots:
       any of the kinds of changes made to an object's name or symbol
     notes: >-
       permissible_values: named/renamed
-    domain: AlleleNomenclatureEvent
+    domain: AlleleNomenclatureEventSlotAnnotation
     range: VocabularyTerm
 
   nomenclature_event_name:
     description: >-
       Name of the VocabularyTerm describing the nomenclature event
-    domain: AlleleNomenclatureEventDTO
+    domain: AlleleNomenclatureEventSlotAnnotationDTO
     range: string
 
   allele_secondary_ids:
     description: Secondary IDs of a given allele
     domain: Allele
-    range: AlleleSecondaryId
+    range: AlleleSecondaryIdSlotAnnotation
     multivalued: true
 
   allele_secondary_id_dtos:
     domain: AlleleDTO
-    range: AlleleSecondaryIdDTO
+    range: AlleleSecondaryIdSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true
@@ -792,11 +782,11 @@ slots:
   allele_notes:
     description: Notes for a given allele
     domain: Allele
-    range: AlleleNote
+    range: AlleleNoteSlotAnnotation
 
   allele_note_dtos:
     domain: AlleleDTO
-    range: AlleleNoteDTO
+    range: AlleleNoteSlotAnnotationDTO
     multivalued: true
 
   allele_synonyms:
@@ -807,7 +797,47 @@ slots:
 
   allele_synonym_dtos:
     domain: AlleleDTO
-    range: AlleleSynonymDTO
+    range: AlleleSynonymSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true
+
+  allele_gene_associations:
+    domain: Allele
+    range: AlleleGeneAssociation
+    multivalued: true
+
+  allele_transcript_associations:
+    domain: Allele
+    range: AlleleTranscriptAssociation
+    multivalued: true
+
+  allele_protein_associations:
+    domain: Allele
+    range: AlleleProteinAssociation
+    multivalued: true
+
+  allele_variant_associations:
+    domain: Allele
+    range: AlleleVariantAssociation
+    multivalued: true
+
+  allele_construct_associations:
+    domain: Allele
+    range: AlleleConstructAssociation
+    multivalued: true
+
+  allele_cell_line_associations:
+    domain: Allele
+    range: AlleleCellLineAssociation
+    multivalued: true
+
+  allele_image_associations:
+    domain: Allele
+    range: AlleleImageAssociation
+    multivalued: true
+
+  allele_origin_associations:
+    domain: Allele
+    range: AlleleOriginAssociation
+    multivalued: true

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -481,6 +481,7 @@ slots:
   primary_image:
     description: >-
       The primary image for an allele that is used to represent the allele on a page.
+    range: boolean
 
   single_allele:
     range: Allele

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -53,7 +53,6 @@ classes:
       - inheritance_mode
       - in_collection
       - is_extinct
-      - sequencing_status
       - allele_mutation_types
       - allele_germline_transmission_status
       - allele_functional_impacts
@@ -71,6 +70,7 @@ classes:
       - allele_cell_line_associations
       - allele_image_associations
       - allele_origin_associations
+      - allele_generation_method_associations
     exact_mappings:
       - SO:0001023
     slot_usage:
@@ -91,7 +91,6 @@ classes:
       - inheritance_mode_name
       - in_collection_name
       - is_extinct
-      - sequencing_status_name
       - allele_mutation_type_dtos
       - allele_germline_transmission_status_dto
       - allele_functional_impact_dtos
@@ -721,20 +720,6 @@ slots:
     domain: Allele
     range: boolean
 
-  sequencing_status:
-    description: >-
-      Status of whether or not the variant genomic location has been verified
-      by sequencing
-    domain: Allele
-    range: VocabularyTerm
-
-  sequencing_status_name:
-    description: >-
-      Name of VocabularyTerm describing the sequencing status from the
-      'Sequencing status vocabulary' vocabulary
-    domain: AlleleDTO
-    range: string
-
   analyses:
     description: >-
       # TODO: added as a result of 'origin' class - please advise on a more descriptive slot/class definition.
@@ -840,4 +825,9 @@ slots:
   allele_origin_associations:
     domain: Allele
     range: AlleleOriginAssociation
+    multivalued: true
+
+  allele_generation_method_associations:
+    domain: Allele
+    range: AlleleGenerationMethodAssociation
     multivalued: true

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -54,6 +54,15 @@ classes:
       - in_collection
       - is_extinct
       - sequencing_status
+      - allele_mutation_types
+      - allele_germline_transmission_status
+      - allele_functional_impacts
+      - allele_molecular_mutations
+      - allele_database_status
+      - allele_secondary_ids
+      - allele_nomenclature_events
+      - allele_notes
+      - allele_synonyms
     exact_mappings:
       - SO:0001023
     slot_usage:
@@ -64,53 +73,157 @@ classes:
       symbol:
         required: true
 
+  AlleleDTO:
+    is_a: GenomicEntityDTO
+    description: >-
+      Ingest class for an Allele object
+    slots:
+      - symbol
+      - reference_curies
+      - inheritance_mode_name
+      - in_collection_name
+      - is_extinct
+      - sequencing_status_name
+      - allele_mutation_type_dtos
+      - allele_germline_transmission_status_dto
+      - allele_functional_impact_dtos
+      - allele_molecular_mutation_dtos
+      - allele_database_status_dto
+      - allele_secondary_id_dtos
+      - allele_nomenclature_event_dtos
+      - allele_note_dtos
+      - allele_synonym_dtos
+
   GenerationMethod:
     is_a: AuditedObject
     slots:
       - mutagenesis_method
       - mutagenesis_target
 
-# SlotAnnotations
-  AlleleSlotAnnotation:
-    is_a: SlotAnnotation
+  GenerationMethodDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - mutagenesis_method_name
+      - mutagenesis_target
+
+  AlleleMutationType:
+    is_a: AuditedObject
     slots:
       - single_allele
+      - mutation_types
       - evidence
 
-  AlleleMutationTypeAnnotation:
-    is_a: AlleleSlotAnnotation
+  AlleleMutationTypeDTO:
+    is_a: AuditedObjectDTO
     slots:
-      - mutation_type
+      - mutation_type_curies
+      - evidence_curies
 
-  AlleleGermlineTransmissionStatusAnnotation:
-    is_a: AlleleSlotAnnotation
+  AlleleGermlineTransmissionStatus:
+    is_a: AuditedObject
     slots:
+      - single_allele
       - germline_transmission_status
+      - evidence
 
-  AlleleFunctionalImpactAnnotation:
-    is_a: AlleleSlotAnnotation
+  AlleleGermlineTransmissionStatusDTO:
+    is_a: AuditedObjectDTO
     slots:
-      - functional_impact
+      - germline_transmission_status_name
+      - evidence_curies
 
-  AlleleMolecularMutationAnnotation:
-    is_a: AlleleSlotAnnotation
+  AlleleFunctionalImpact:
+    is_a: AuditedObject
     slots:
+      - single_allele
+      - functional_impacts
+      - evidence
+
+  AlleleFunctionalImpactDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - functional_impact_names
+      - evidence_curies
+
+  AlleleMolecularMutation:
+    is_a: AuditedObject
+    slots:
+      - single_allele
       - molecular_mutations
+      - evidence
 
-  AlleleDatabaseStatusAnnotation:
-    is_a: AlleleSlotAnnotation
+  AlleleMolecularMutationDTO:
+    is_a: AuditedObjectDTO
     slots:
-      - database_status
+      - molecular_mutation_names
+      - evidence_curies
 
-  AlleleSecondaryIdAnnotation:
-    is_a: AlleleSlotAnnotation
+  AlleleDatabaseStatus:
+    is_a: AuditedObject
+    slots:
+      - single_allele
+      - database_status
+      - evidence
+
+  AlleleDatabaseStatusDTO:
+    is_a: AuditedObject
+    slots:
+      - database_status_name
+      - evidence_curies
+
+  AlleleSecondaryId:
+    is_a: AuditedObject
+    slots:
+      - single_allele
+      - secondary_id
+      - evidence
+
+  AlleleSecondaryIdDTO:
+    is_a: AuditedObjectDTO
     slots:
       - secondary_id
+      - evidence_curies
 
-  AlleleNomenclatureAnnotation:
-    is_a: AlleleSlotAnnotation
+  AlleleNomenclatureEvent:
+    is_a: AuditedObject
     slots:
+      - single_allele
       - nomenclature_event
+      - evidence
+
+  AlleleNomenclatureEventDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - nomenclature_event_name
+      - evidence_curies
+
+  AlleleNote:
+    is_a: AuditedObject
+    slots:
+      - single_allele
+      - related_note
+      - evidence
+
+  AlleleNoteDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - note_dto
+      - evidence_curies
+
+  AlleleSynonym:
+    is_a: AuditedObject
+    slots:
+      - single_allele
+      - synonym
+      - synonym_scope
+      - evidence
+
+  AlleleSynonymDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - synonym_dto
+      - synonym_scope_name
+      - evidence_curies
 
 # Allele Associations
 
@@ -124,6 +237,15 @@ classes:
         range: Allele
       object:
         range: GenerationMethod
+
+  AlleleGenerationMethodAssociationDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - allele_curie
+      - predicate_name
+      - generation_method_dto
+      - evidence_curies
+      - mutation_target_strain_curie
 
   AlleleGenomicEntityAssociation:
     is_a: Association
@@ -144,6 +266,19 @@ classes:
       evidence:
         required: true
 
+  AlleleGenomicEntityAssociationDTO:
+    is_a: AuditedObjectDTO
+    abstract: true
+    slots:
+      - allele_curie
+      - ro_term_curie
+      - evidence_curies
+      - evidence_code_curie
+      - note_dto
+    slot_usage:
+      evidence_curies:
+        required: true
+
   AlleleGeneAssociation:
     is_a: AlleleGenomicEntityAssociation
     description: >-
@@ -151,6 +286,11 @@ classes:
     slot_usage:
       object:
         range: Gene
+
+  AlleleGeneAssociationDTO:
+    is_a: AlleleGenomicEntityAssociationDTO
+    slots:
+      - gene_curie
 
   AlleleTranscriptAssociation:
     is_a: AlleleGenomicEntityAssociation
@@ -160,6 +300,11 @@ classes:
       object:
         range: Transcript
 
+  AlleleTranscriptAssociationDTO:
+    is_a: AlleleGenomicEntityAssociationDTO
+    slots:
+      - transcript_curie
+
   AlleleProteinAssociation:
     is_a: AlleleGenomicEntityAssociation
     description: >-
@@ -167,6 +312,11 @@ classes:
     slot_usage:
       object:
         range: Protein
+
+  AlleleProteinAssociationDTO:
+    is_a: AlleleGenomicEntityAssociationDTO
+    slots:
+      - protein_curie
 
   AlleleVariantAssociation:
     is_a: AlleleGenomicEntityAssociation
@@ -179,6 +329,11 @@ classes:
         range: Allele
       object:
         range: Variant
+
+  AlleleVariantAssociationDTO:
+    is_a: AlleleGenomicEntityAssociationDTO
+    slots:
+      - variant_curie
 
   AlleleConstructAssociation:
     is_a: AlleleGenomicEntityAssociation
@@ -193,6 +348,11 @@ classes:
       object:
         range: Construct
 
+  AlleleConstructAssociationDTO:
+      is_a: AlleleGenomicEntityAssociationDTO
+      slots:
+        - construct_curie
+
   AlleleCellLineAssociation: # do mutant/parent/embryonic cell line associations need to be split out?
     is_a: Association
     description: >-
@@ -206,6 +366,13 @@ classes:
         range: VocabularyTerm
       object:
         range: CellLine
+
+  AlleleCellLineAssociationDTO:
+      is_a: AuditedObjectDTO
+      slots:
+        - allele_curie
+        - predicate_name
+        - cell_line_curie
 
   AlleleImageAssociation:
     is_a: Association
@@ -225,15 +392,13 @@ classes:
           Can be null; if false, maybe you would show all the images.
           We need to revisit this issue.
 
-  AlleleNotesAssociation:
-    is_a: Association
-    description: >-
-      The relationship between an allele and a note.
-    slot_usage:
-      subject:
-        range: Allele
-      object:
-        range: Note
+  AlleleImageAssociationDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - allele_curie
+      - predicate_name
+      - image_curie
+      - primary_image
 
   AlleleOriginAssociation:
     is_a: Association
@@ -245,18 +410,12 @@ classes:
         object:
             range: AffectedGenomicModel
 
-  AlleleSynonymAssociation:
-    is_a: Association
-    description: >-
-      The relationship between an allele and a synonym.
+  AlleleOriginAssociationDTO:
+    is_a: AuditedObjectDTO
     slots:
-      - synonym_scope
-    slot_usage:
-      subject:
-        range: Allele
-      object:
-        range: Synonym
-
+      - allele_curie
+      - predicate_name
+      - agm_curie
 
 # Other classes roughly grouped with the Allele class because they have relationships to Allele and were
 # designed close to the time the Allele class was designed.  These could be broken out into their own yaml files.
@@ -330,6 +489,22 @@ slots:
   single_allele:
     range: Allele
 
+  allele_curie:
+    range: string
+    required: true
+
+  ro_term_curie:
+    range: string
+    required: true
+
+  construct_curie:
+    range: string
+    required: true
+
+  cell_line_curie:
+    range: string
+    required: true
+
   mutagenesis_method:
     alias: ["mutagen"]
     range: VocabularyTerm
@@ -338,6 +513,15 @@ slots:
       spontaneous / naturally occurring / radiation-induced / recombinant /
       ENU / CRISPR / TALEN / gamma rays / not specified / spontaneous / DNA /
       DNA AND CRISPR / DNA and TALEN / zinc finger nuclease / EMS
+
+  mutagenesis_method_name:
+    description: >-
+      Name of the VocabularyTerm describing the mutagenesis method, e.g.
+      spontaneous / naturally occurring / radiation-induced / recombinant /
+      ENU / CRISPR / TALEN / gamma rays / not specified / spontaneous / DNA /
+      DNA AND CRISPR / DNA and TALEN / zinc finger nuclease / EMS
+    domain: AlleleGenerationMethodAssociationDTO
+    range: string
 
   mutagenesis_target:
     alias: ["mutagee"]
@@ -350,50 +534,150 @@ slots:
     description: >-
       The particular strain (solely for and from MGI) that is targeted
       by the generation method for a particular allele.
-    range: string # VocabularyTerm?
+    range: AffectedGenomicModel
+
+  mutation_target_strain_curie:
+    description: >-
+      Curie of the particular strain that is targeted by the generation method
+      for a particular allele (MGI only)
+    domain: AlleleGenerationMethodAssociationDTO
+    range: string
+
+  generation_method_dto:
+    domain: AlleleGenerationMethodAssociationDTO
+    range: GenerationMethodDTO
 
   construct_components:
     multivalued: true
     domain: Construct
     range: GenomicEntity
 
+  allele_molecular_mutations:
+    description: Molecular mutations of a given allele
+    domain: Allele
+    range: AlleleMolecularMutation
+    multivalued: true
+
   molecular_mutations:
     description: >-
       Description of the DNA changes if precise
       genomic location unknown
-    domain: Allele
-    multivalued: true
+    domain: AlleleMolecularMutation
     range: string
+    multivalued: true
 
-  mutation_type:
-    description: SO term for type of mutation
-    domain: Allele
-    range: SOTerm
+  allele_molecular_mutation_dtos:
+    domain: AlleleDTO
+    range: AlleleMolecularMutationDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
 
-  mutation_description:
+  molecular_mutation_names:
     description: >-
-      Additional information about the nature of the mutation not captured
-      by the SOTerm
+      Name of the VocabularyTerm describing the molecular mutation
+    domain: AlleleMolecularMutationDTO
+    range: string
+    multivalued: true
 
-  functional_impact:
+  allele_mutation_types:
+    description: Mutation types for a given allele
+    domain: Allele
+    range: AlleleMutationType
+    multivalued: true
+
+  allele_mutation_type_dtos:
+    domain: AlleleDTO
+    range: AlleleMutationTypeDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  mutation_types:
+    description: SO term for type of mutation
+    domain: AlleleMutationType
+    range: SOTerm
+    multivalued: true
+
+  mutation_type_curies:
+    description: Curies of SOTerms representing mutation type
+    domain: AlleleMutationTypeDTO
+    range: string
+    multivalued: true
+
+  allele_functional_impacts:
+    description: Functional impacts of a given allele
+    domain: Allele
+    range: AlleleFunctionalImpact
+    multivalued: true
+
+  allele_functional_impact_dtos:
+    domain: AlleleDTO
+    range: AlleleFunctionalImpactDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  functional_impacts:
     description: >-
       Experimentally assessed functional impact of the
       allele, e.g. knockout / amorphic
-    domain: Allele
+    domain: AlleleFunctionalImpact
+    range: VocabularyTerm
+    multivalued: true
+
+  functional_impact_names:
+    description: >-
+      Name of the VocabularyTerm describing the functional impact
+    domain: AlleleFunctionalImpactDTO
     range: string
     multivalued: true
+
+  allele_germline_transmission_status:
+    description: Germline transmission status for a given allele
+    domain: Allele
+    range: AlleleGermlineTransmissionStatus
+
+  allele_germline_transmission_status_dto:
+    domain: AlleleDTO
+    range: AlleleGermlineTransmissionStatusDTO
+    inlined: true
 
   germline_transmission_status:
     description: >-
       For alleles made in cell lines, have they been
       transmitted to the germline of an animal
-    domain: Allele
+    domain: AlleleGermlineTransmissionStatus
     range: VocabularyTerm
+
+  germline_transmission_status_name:
+    description: >-
+      Name of the VocabularyTerm representing the germline transmission
+      status
+    domain: AlleleGermlineTransmissionStatusDTO
+    range: string
+
+  allele_database_status:
+    description: Database status of a given allele
+    domain: Allele
+    range: AlleleDatabaseStatus
+
+  allele_database_status_dto:
+    domain: AlleleDTO
+    range: AlleleDatabaseStatusDTO
+    inlined: true
 
   database_status:
     description: >-
       Database status of the allele
+    domain: AlleleDatabaseStatus
     range: VocabularyTerm
+
+  database_status_name:
+    description: >-
+      Name of the VocabularyTerm describing the database status
+    domain: AlleleDatabaseStatusDTO
+    range: string
 
   inheritance_mode:
     description: >-
@@ -403,11 +687,23 @@ slots:
     domain: Allele
     range: VocabularyTerm
 
+  inheritance_mode_name:
+    description: >-
+      Name of VocabularyTerm describing the inheritance mode
+    domain: AlleleDTO
+    range: string
+
   in_collection:
     description: >-
       Set of high-throughput alleles made by large projects
     domain: Allele
     range: VocabularyTerm
+
+  in_collection_name:
+    description: >-
+      Name of VocabularyTerm describing the collection
+    domain: AlleleDTO
+    range: string
 
   transposon_insertion:
     description: >-
@@ -436,14 +732,78 @@ slots:
     domain: Allele
     range: VocabularyTerm
 
+  sequencing_status_name:
+    description: >-
+      Name of VocabularyTerm describing the sequencing status
+    domain: AlleleDTO
+    range: string
+
   analyses:
     description: >-
       # TODO: added as a result of 'origin' class - please advise on a more descriptive slot/class definition.
 
+  allele_nomenclature_events:
+    description: Nomenclature events of a given allele
+    domain: Allele
+    range: AlleleNomenclatureEvent
+    multivalued: true
+
+  allele_nomenclature_event_dtos:
+    domain: AlleleDTO
+    range: AlleleNomenclatureEventDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
   nomenclature_event:
     description: >-
       any of the kinds of changes made to an object's name or symbol
-    range: nomenclature_event_enum
+    notes: >-
+      permissible_values: named/renamed
+    domain: AlleleNomenclatureEvent
+    range: VocabularyTerm
+
+  nomenclature_event_name:
+    description: >-
+      Name of the VocabularyTerm describing the nomenclature event
+    domain: AlleleNomenclatureEventDTO
+    range: string
+
+  allele_secondary_ids:
+    description: Secondary IDs of a given allele
+    domain: Allele
+    range: AlleleSecondaryId
+    multivalued: true
+
+  allele_secondary_id_dtos:
+    domain: AlleleDTO
+    range: AlleleSecondaryIdDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  allele_notes:
+    description: Notes for a given allele
+    domain: Allele
+    range: AlleleNote
+
+  allele_note_dtos:
+    domain: AlleleDTO
+    range: AlleleNoteDTO
+    multivalued: true
+
+  allele_synonyms:
+    description: Synonyms of a given allele
+    domain: Allele
+    range: Synonym
+    multivalued: true
+
+  allele_synonym_dtos:
+    domain: AlleleDTO
+    range: AlleleSynonymDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
 
 enums:
   construct_component_relation_enum:
@@ -458,9 +818,3 @@ enums:
   sqtr_relation_enum:
     permissible_values:
       targets:
-
-  nomenclature_event_enum:
-    permissible_values:
-      named:
-      renamed:
-      # merged?

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -449,13 +449,16 @@ classes:
         required: true
 
   SequenceTargetingReagentToGeneAssociation:
-    description: the relationship between a Sequence Targeting Reagent and its targeted genes.
+    description: >-
+      the relationship between a Sequence Targeting Reagent and its targeted
+      genes. The predicate should be a VocabularyTerm with one of the following
+      values - targets
     is_a: Association
     slots:
       - references
     slot_usage:
       predicate:
-        range: sqtr_relation_enum
+        range: VocabularyTerm
       subject:
         range: SequenceTargetingReagent
       object:
@@ -463,9 +466,13 @@ classes:
 
   ConstructComponentAssociation:
     is_a: Association
+    description: >-
+      The predicate should be a VocabularyTerm with one of the following
+      values - expresses (RO:0002292) / is_regulated_by (RO:0002334) /
+      targets (RO:0002436)
     slot_usage:
       predicate:
-        range: construct_component_relation_enum
+        range: VocabularyTerm
       subject:
         range: Construct
       object:
@@ -482,9 +489,6 @@ slots:
   primary_image:
     description: >-
       The primary image for an allele that is used to represent the allele on a page.
-
-  origin:
-    range: boolean
 
   single_allele:
     range: Allele
@@ -689,7 +693,8 @@ slots:
 
   inheritance_mode_name:
     description: >-
-      Name of VocabularyTerm describing the inheritance mode
+      Name of VocabularyTerm describing the inheritance mode from the 'Allele
+      inheritance mode vocabulary' vocabulary
     domain: AlleleDTO
     range: string
 
@@ -701,7 +706,8 @@ slots:
 
   in_collection_name:
     description: >-
-      Name of VocabularyTerm describing the collection
+      Name of VocabularyTerm describing the collection from the 'Allele
+      collection vocabulary' Vocabulary
     domain: AlleleDTO
     range: string
 
@@ -734,7 +740,8 @@ slots:
 
   sequencing_status_name:
     description: >-
-      Name of VocabularyTerm describing the sequencing status
+      Name of VocabularyTerm describing the sequencing status from the
+      'Sequencing status vocabulary' vocabulary
     domain: AlleleDTO
     range: string
 
@@ -804,17 +811,3 @@ slots:
     multivalued: true
     inlined: true
     inlined_as_list: true
-
-enums:
-  construct_component_relation_enum:
-    permissible_values:
-      expresses:
-        meaning: RO:0002292
-      is_regulated_by:
-        meaning: RO:0002334
-      targets:
-        meaning: RO:0002436
-
-  sqtr_relation_enum:
-    permissible_values:
-      targets:

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -362,6 +362,7 @@ classes:
         - allele_curie
         - predicate_name
         - cell_line_curie
+        - evidence_curies
 
   AlleleImageAssociation:
     is_a: Association
@@ -388,6 +389,7 @@ classes:
       - predicate_name
       - image_curie
       - primary_image
+      - evidence_curies
 
   AlleleOriginAssociation:
     is_a: Association
@@ -405,6 +407,7 @@ classes:
       - allele_curie
       - predicate_name
       - agm_curie
+      - evidence_curies
 
 # Other classes roughly grouped with the Allele class because they have relationships to Allele and were
 # designed close to the time the Allele class was designed.  These could be broken out into their own yaml files.

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -68,6 +68,19 @@ classes:
       - internal
       - obsolete
 
+  AuditedObjectDTO:
+    description: >-
+      Base class for all other LinkML DTO classes.
+    slots:
+      - created_by_curie
+      - date_created
+      - updated_by_curie
+      - date_updated
+      - db_date_created
+      - db_date_updated
+      - internal
+      - obsolete
+
   BiologicalEntity:
     is_a: AuditedObject
     description: >-
@@ -83,6 +96,17 @@ classes:
       curie:
         required: true
 
+  BiologicalEntityDTO:
+    is_a: AuditedObjectDTO
+    abstract: true
+    slots:
+      - curie
+      - taxon_curie
+    slot_usage:
+      taxon_curie:
+        required: true
+      curie:
+        required: true
 
   GenomicEntity:
     is_a: BiologicalEntity
@@ -97,6 +121,15 @@ classes:
       - cross_references
       - secondary_identifiers
       - genomic_locations
+
+  GenomicEntityDTO:
+    is_a: BiologicalEntityDTO
+    slots:
+      - name
+      - synonym_dtos
+      - cross_reference_dtos
+      - secondary_identifiers
+      - genomic_location_dtos
 
   Transcript:
     is_a: GenomicEntity
@@ -125,9 +158,22 @@ classes:
       curie:
         required: true
 
+  CrossReferenceDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - curie
+      - page_areas
+      - display_name
+      - prefix
+
 
   Synonym:
     is_a: AuditedObject
+    slots:
+      - name
+
+  SynonymDTO:
+    is_a: AuditedObjectDTO
     slots:
       - name
 
@@ -156,6 +202,18 @@ classes:
           - value: gene_function_summary
           - value: gene_phenotype_summary
 
+  NoteDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - free_text
+      - note_type_name
+      - evidence_curies
+    slot_usage:
+      free_text:
+        required: true
+      note_type_name:
+        required_true
+
   SlotAnnotation:
     is_a: AuditedObject
     description: >-
@@ -163,21 +221,21 @@ classes:
       to a slot in the context of its referencing class, that can not be fully captured using an Association between
       the full class itself, and an InformationContentEntity. Evidence and provenance can exist here in the form of an
       evidence code, a publication, a personal communication or any other kind of InformationContentEntity.
-      SlotAnnotation classes are used where the slot is not referencing a class in and of itself, and often has a 
+      SlotAnnotation classes are used where the slot is not referencing a class in and of itself, and often has a
       scalar range.
     notes: >-
-      A good example of the use of a SlotAnnotation class is the use case of attributing one of many functional 
-      impacts of an allele to a publication.  AlleleFunctionalImpact is the SlotAnnotation class that represents 
-      this use case. 
+      A good example of the use of a SlotAnnotation class is the use case of attributing one of many functional
+      impacts of an allele to a publication.  AlleleFunctionalImpact is the SlotAnnotation class that represents
+      this use case.
 
   Association:
     is_a: AuditedObject
     description: >-
-      A typed association between two entities, supported by evidence.  Associations have three base slots: subject, 
-      object, and predicate, but they can have any number of additional attributes that help qualify the relationship 
-      between the subject and the object.  The subject is the curie (or identifier) of the class that is the subject 
-      of the association, and likewise the object is the curie (or identifier of the class that is the object. The 
-      relationship between subject and object is defined by the predicate slot (which can also be constrained 
+      A typed association between two entities, supported by evidence.  Associations have three base slots: subject,
+      object, and predicate, but they can have any number of additional attributes that help qualify the relationship
+      between the subject and the object.  The subject is the curie (or identifier) of the class that is the subject
+      of the association, and likewise the object is the curie (or identifier of the class that is the object. The
+      relationship between subject and object is defined by the predicate slot (which can also be constrained
       using the range of the predicate).
     exact_mappings:
       - biolink:association
@@ -266,6 +324,29 @@ classes:
       - start
       - end
 
+  GenomicLocationDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - genomic_entity_curie
+      - predicate   # what should the predicate range be for this class? CG
+      - chromosome_curie
+      - assembly_curie
+      - start
+      - end
+    slot_usage:
+      genomic_entity_curie:
+        required: true
+      predicate:
+        required: true
+      chromosome_curie:
+        required: true
+      assembly_curie:
+        required: true
+      start:
+        required: true
+      end:
+        required: true
+
   Protein:
     is_a: GenomicEntity
 
@@ -293,8 +374,16 @@ slots:
     description: the text string of the synonym
 
   synonym_scope:
-    description: the scope of the synonym, e.g. 'EXACT', 'NARROW' or 'RELATED'
-    range: synonym_scope_enum
+    description: >-
+      the scope of the synonym - permissible values are narrow /
+      broad / related / exact
+    range: VocabularyTerm
+
+  synonym_scope_name:
+    description: >-
+      Name of the VocabularyTerm representing the scope of the
+      synonym - permissible values are narrow / broad / related / exact
+    range: string
 
   start:
     description: The start of the feature in positive 1-based integer coordinates
@@ -367,6 +456,12 @@ slots:
       The type of note: e.g., cytology, comment, summary. Permissible values for 'note_type' currently = disease_summary, disease_note
     range: VocabularyTerm
 
+  note_type_name:
+    description: >-
+      Name of VocabularyTerm representing note type
+    domain: NoteDTO
+    range: string
+
   internal:
     description: >-
       Classifies the entity as private (for internal use) or not (for public use).
@@ -390,6 +485,9 @@ slots:
       Singular version of related_notes
     range: Note
     multivalued: false
+
+  note_dto:
+    range: NoteDTO
 
   generated_by:
     description: >-
@@ -435,6 +533,12 @@ slots:
     multivalued: false
     range: NCBITaxonTerm
 
+  taxon_curie:
+    description: >-
+      Curie of the NCBITaxonTerm representing the taxon from which the
+      biological entity derives
+    range: string
+
   secondary_identifiers:
     aliases: ['secondary_ids']
     multivalued: true
@@ -447,6 +551,11 @@ slots:
   genomic_locations:
     domain: GenomicEntity
     range: GenomicLocation
+    multivalued: true
+
+  genomic_location_dtos:
+    domain: GenomicEntityDTO
+    range: GenomicLocationDTO
     multivalued: true
 
   table_key:
@@ -493,12 +602,26 @@ slots:
     domain: AuditedObject
     range: Person
 
+  created_by_curie:
+    description: >-
+      Curie of the Person object representing the individual that created the
+      entity
+    domain: AuditedObjectDTO
+    range: string
+
   updated_by:
     description: >-
       The individual that last modified the entity.
     multivalued: false
     domain: AuditedObject
     range: Person
+
+  updated_by_curie:
+    description: >-
+      Curie of the Person object representing the individual that updated the
+      entity
+    domain: AuditedObjectDTO
+    range: string
 
   release:
     description: MOD release ID
@@ -543,6 +666,12 @@ slots:
     inlined: true
     inlined_as_list: true
 
+  cross_reference_dtos:
+    range: CrossReferenceDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
   symbol:
     description: >-
       Symbol for a particular thing
@@ -554,6 +683,14 @@ slots:
     description: holds between a named thing and a synonym
     multivalued: true
     range: Synonym
+
+  synonym_dtos:
+    range: SynonymDTO
+    multivalued: true
+
+  synonym_dto:
+    range: SynonymDTO
+    multivalued: false
 
   negated:
     range: boolean
@@ -654,6 +791,22 @@ slots:
     description: last identifier in a range
     range: Identifier
 
+  genomic_entity_curie:
+    range: string
+
+  assembly_curie:
+    range: string
+
+  chromosome_curie:
+    range: string
+
+  transcript_curie:
+    range: string
+    required: true
+
+  protein_curie:
+    range: string
+    required: true
 
   ## --------------------
 ## ASSOCIATION SLOTS
@@ -687,6 +840,12 @@ slots:
     required: true
     exact_mappings:
       - biolink:predicate
+
+  predicate_name:
+    description: >-
+      Name of VocabularyTerm representing predicate of an Association
+    required: true
+    range: string
 
 ## ----------
 ## PREDICATES

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -489,6 +489,10 @@ slots:
   note_dto:
     range: NoteDTO
 
+  note_dtos:
+    range: NoteDTO
+    multivalued: true
+
   generated_by:
     description: >-
       Holds between a material entity and an Agent that generated it:

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -166,7 +166,6 @@ classes:
       - display_name
       - prefix
 
-
   Synonym:
     is_a: AuditedObject
     slots:
@@ -213,20 +212,6 @@ classes:
         required: true
       note_type_name:
         required_true
-
-  SlotAnnotation:
-    is_a: AuditedObject
-    description: >-
-      SlotAnnotation classes should be used when we need to attach metadata (in particular evidence and provenance)
-      to a slot in the context of its referencing class, that can not be fully captured using an Association between
-      the full class itself, and an InformationContentEntity. Evidence and provenance can exist here in the form of an
-      evidence code, a publication, a personal communication or any other kind of InformationContentEntity.
-      SlotAnnotation classes are used where the slot is not referencing a class in and of itself, and often has a
-      scalar range.
-    notes: >-
-      A good example of the use of a SlotAnnotation class is the use case of attributing one of many functional
-      impacts of an allele to a publication.  AlleleFunctionalImpact is the SlotAnnotation class that represents
-      this use case.
 
   Association:
     is_a: AuditedObject
@@ -458,7 +443,8 @@ slots:
 
   note_type_name:
     description: >-
-      Name of VocabularyTerm representing note type
+      Name of VocabularyTerm representing note type selected from the
+      appropriate Vocabulary
     domain: NoteDTO
     range: string
 

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -213,6 +213,27 @@ classes:
       note_type_name:
         required_true
 
+  SlotAnnotation:
+    is_a: AuditedObject
+    description: >-
+      SlotAnnotation classes should be used when we need to attach metadata (in particular evidence and provenance)
+      to a slot in the context of its referencing class, that can not be fully captured using an Association between
+      the full class itself, and an InformationContentEntity. Evidence and provenance can exist here in the form of an
+      evidence code, a publication, a personal communication or any other kind of InformationContentEntity.
+      SlotAnnotation classes are used where the slot is not referencing a class in and of itself, and often has a
+      scalar range.
+    notes: >-
+      A good example of the use of a SlotAnnotation class is the use case of attributing one of many functional
+      impacts of an allele to a publication.  AlleleFunctionalImpact is the SlotAnnotation class that represents
+      this use case.
+    slots:
+      - evidence
+
+  SlotAnnotationDTO:
+    is_a: AuditedObjectDTO
+    slots:
+      - evidence_curies
+
   Association:
     is_a: AuditedObject
     description: >-

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -211,7 +211,7 @@ classes:
       free_text:
         required: true
       note_type_name:
-        required_true
+        required: true
 
   SlotAnnotation:
     is_a: AuditedObject

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -53,7 +53,7 @@ classes:
       - symbol
       - related_notes
       - gene_type
-      - gene_types_secondary    
+      - gene_types_secondary
       - designating_laboratories
       - designating_persons
       - trans_splice_leaders
@@ -113,6 +113,9 @@ classes:
 
 slots:
 
+  gene_curie:
+    range: string
+
   gene_type:
     description: SOTerm describing gene type
     domain: Gene
@@ -125,7 +128,7 @@ slots:
     multivalued: true
     domain: Gene
     range: SOTerm
-        
+
   designating_laboratories:
     description: >-
       A laboratory, rarely laboratories, which designated this gene
@@ -277,4 +280,3 @@ slots:
     multivalued: true
     domain: GeneHistory
     range: Gene
-

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -81,6 +81,13 @@ classes:
           on the production environment (curation.alliancegenome.org). New terms
           can be added as needed.
 
+  GeneDTO:
+    is_a: GenomicEntityDTO
+    description: Ingest class for genes
+    slots:
+      - symbol
+      - gene_type_curie
+
   GeneticMapPosition:
     description: >-
       A genetic map position.
@@ -115,11 +122,17 @@ slots:
 
   gene_curie:
     range: string
+    required: true
 
   gene_type:
     description: SOTerm describing gene type
     domain: Gene
     range: SOTerm
+
+  gene_type_curie:
+    description: Curie of SOTerm describing gene type
+    domain: GeneDTO
+    range: string
 
   gene_types_secondary:
     description: >-

--- a/model/schema/image.yaml
+++ b/model/schema/image.yaml
@@ -231,3 +231,7 @@ slots:
     range: integer
     required: true
     multivalued: false
+
+  image_curie:
+    range: string
+    required: true

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -63,7 +63,7 @@ slots:
   agm_ingest_set:
     description: >-
     domain: Ingest
-    range: AffectedGenomicModel
+    range: AffectedGenomicModelDTO
     multivalued: true
     mixins:
       - object_set
@@ -144,7 +144,7 @@ slots:
   disease_allele_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleDiseaseAnnotation
+    range: AlleleDiseaseAnnotationDTO
     multivalued: true
     mixins:
       - object_set
@@ -152,7 +152,7 @@ slots:
   disease_agm_ingest_set:
     description: >-
     domain: Ingest
-    range: AGMDiseaseAnnotation
+    range: AGMDiseaseAnnotationDTO
     multivalued: true
     mixins:
       - object_set
@@ -160,7 +160,7 @@ slots:
   disease_gene_ingest_set:
     description: >-
     domain: Ingest
-    range: GeneDiseaseAnnotation
+    range: GeneDiseaseAnnotationDTO
     multivalued: true
     mixins:
       - object_set
@@ -176,7 +176,7 @@ slots:
   gene_ingest_set:
     description: >-
     domain: Ingest
-    range: Gene
+    range: GeneDTO
     multivalued: true
     mixins:
       - object_set

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -55,7 +55,7 @@ slots:
   allele_ingest_set:
     description: >-
     domain: Ingest
-    range: Allele
+    range: AlleleDTO
     multivalued: true
     mixins:
       - object_set
@@ -87,7 +87,7 @@ slots:
   allele_variant_association_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleVariantAssociation
+    range: AlleleVariantAssociationDTO
     multivalued: true
     mixins:
       - object_set
@@ -95,7 +95,7 @@ slots:
   allele_gene_association_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleGeneAssociation
+    range: AlleleGeneAssociationDTO
     multivalued: true
     mixins:
       - object_set
@@ -103,7 +103,7 @@ slots:
   allele_transcript_association_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleTranscriptAssociation
+    range: AlleleTranscriptAssociationDTO
     multivalued: true
     mixins:
       - object_set
@@ -111,7 +111,7 @@ slots:
   allele_protein_association_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleProteinAssociation
+    range: AlleleProteinAssociationDTO
     multivalued: true
     mixins:
       - object_set
@@ -119,7 +119,7 @@ slots:
   allele_construct_association_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleConstructAssociation
+    range: AlleleConstructAssociationDTO
     multivalued: true
     mixins:
       - object_set
@@ -128,7 +128,7 @@ slots:
   allele_cell_line_association_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleCellLineAssociation
+    range: AlleleCellLineAssociationDTO
     multivalued: true
     mixins:
       - object_set
@@ -136,7 +136,7 @@ slots:
   allele_origin_association_ingest_set:
     description: >-
     domain: Ingest
-    range: AlleleOriginAssociation
+    range: AlleleOriginAssociationDTO
     multivalued: true
     mixins:
       - object_set
@@ -191,71 +191,6 @@ slots:
       This is necessary in a json document to provide context for a list, and
       to allow for a single json object that combines multiple object types
 
-  allele_mutation_type_annotation_ingest_set:
-    description: >-
-    domain: Ingest
-    range: AlleleMutationTypeAnnotation
-    multivalued: true
-    mixins:
-      - object_set
-
-  allele_germline_transmission_status_annotation_ingest_set:
-    description: >-
-    domain: Ingest
-    range: AlleleGermlineTransmissionStatusAnnotation
-    multivalued: true
-    mixins:
-      - object_set
-
-  allele_functional_impact_annotation_ingest_set:
-    description: >-
-    domain: Ingest
-    range: AlleleFunctionalImpactAnnotation
-    multivalued: true
-    mixins:
-      - object_set
-
-  allele_molecular_mutation_annotation_ingest_set:
-    description: >-
-    domain: Ingest
-    range: AlleleMolecularMutationAnnotation
-    multivalued: true
-    mixins:
-      - object_set
-
-  allele_database_status_annotation_ingest_set:
-    description: >-
-    domain: Ingest
-    range: AlleleDatabaseStatusAnnotation
-    multivalued: true
-    mixins:
-      - object_set
-
-  allele_generation_method_ingest_set:
-    description: >-
-    domain: Ingest
-    range: GenerationMethod
-    multivalued: true
-    mixins:
-      - object_set
-
-  allele_secondary_id_annotation_ingest_set:
-    description: >-
-    domain: Ingest
-    range: AlleleSecondaryIdAnnotation
-    multivalued: true
-    mixins:
-      - object_set
-
-  allele_nomenclature_annotation_ingest_set:
-    description: >-
-    domain: Ingest
-    range: AlleleNomenclatureAnnotation
-    multivalued: true
-    mixins:
-      - object_set
-
-
 
 classes:
   Ingest:
@@ -278,11 +213,3 @@ classes:
       - agm_ingest_set
       - sqtr_ingest_set
       - ontology_closure_ingest_set
-      - allele_mutation_type_annotation_ingest_set
-      - allele_germline_transmission_status_annotation_ingest_set
-      - allele_functional_impact_annotation_ingest_set
-      - allele_molecular_mutation_annotation_ingest_set
-      - allele_database_status_annotation_ingest_set
-      - allele_generation_method_ingest_set
-      - allele_secondary_id_annotation_ingest_set
-      - allele_nomenclature_annotation_ingest_set

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -141,6 +141,22 @@ slots:
     mixins:
       - object_set
 
+  allele_generation_method_association_ingest_set:
+    description: >-
+    domain: Ingest
+    range: AlleleGenerationMethodAssociationDTO
+    multivalued: true
+    mixins:
+      - object_set
+
+  allele_image_association_ingest_set:
+    description: >-
+    domain: Ingest
+    range: AlleleImageAssociationDTO
+    multivalued: true
+    mixins:
+      - object_set
+
   disease_allele_ingest_set:
     description: >-
     domain: Ingest
@@ -210,6 +226,8 @@ classes:
       - allele_construct_association_ingest_set
       - allele_cell_line_association_ingest_set
       - allele_origin_association_ingest_set
+      - allele_image_association_ingest_set
+      - allele_generation_method_association_ingest_set
       - agm_ingest_set
       - sqtr_ingest_set
       - ontology_closure_ingest_set

--- a/model/schema/ontologyTerm.yaml
+++ b/model/schema/ontologyTerm.yaml
@@ -110,7 +110,13 @@ slots:
     range: integer
 
   evidence_code_curie:
+    description: Curie of ECOTerm
     range: string
+
+  evidence_code_curies:
+    description: List of ECOTerm curies
+    range: string
+    multivalued: true
 
 classes:
 

--- a/model/schema/ontologyTerm.yaml
+++ b/model/schema/ontologyTerm.yaml
@@ -109,6 +109,9 @@ slots:
   distance_between:
     range: integer
 
+  evidence_code_curie:
+    range: string
+
 classes:
 
   OntologyTerm:
@@ -159,7 +162,7 @@ classes:
       distance_between:
         description: >-
           distance_between is zero for reflexive–transitive closure
-          each node has an ancestor or descendant of itself 
+          each node has an ancestor or descendant of itself
 
   DOTerm:
     is_a: OntologyTerm

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -530,7 +530,8 @@ slots:
 
   annotation_type_name:
     description: >-
-      Name of the VocabularyTerm describing the annotation type
+      Name of the VocabularyTerm describing the annotation type selected from
+      the 'Annotation types' Vocabulary
     domain: DiseaseAnnotationDTO
     range: string
 
@@ -700,15 +701,16 @@ slots:
 
   disease_genetic_modifier_relation_name:
     description: >-
-      Name of the VocabularyTerm from the 'Disease genetic modifiers' vocabulary
-      that describes how the genetic modifier modifies the disease model.
+      Name of the VocabularyTerm that describes how the genetic modifier
+      modifies the disease model, selected from the 'Disease genetic modifier
+      relations' Vocabulary.
     domain: DiseaseAnnotationDTO
     range: string
 
   disease_qualifiers:
     description: >-
-      Submitted values should be vocabulary terms from the 'Disease Qualifiers'
-      vocabulary
+      Submitted values should be vocabulary terms from the 'Disease qualifiers'
+      Vocabulary
     domain: DiseaseAnnotation
     multivalued: true
     range: VocabularyTerm

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -179,7 +179,7 @@ classes:
     description: >-
       An annotation asserting an association between a biological entity and a disease supported by evidence.
     slots:
-      - disease_annotation_curie
+      - curie
       - unique_id
       - mod_entity_id
       - negated
@@ -196,7 +196,7 @@ classes:
       - disease_genetic_modifier
       - disease_genetic_modifier_relation
     slot_usage:
-      disease_annotation_curie:
+      curie:
         description: >-
           The Alliance-minted ID for the disease annotation. The ID is of the format
           AGRKB:100000000000001, where the first three digits represent the
@@ -260,6 +260,30 @@ classes:
           on the production environment (curation.alliancegenome.org). New terms
           can be added as needed.
 
+  DiseaseAnnotationDTO:
+    is_a: AuditedObjectDTO
+    abstract: true
+    description: >-
+      Ingest class for association between a biological entity and a disease
+    slots:
+      - disease_relation_name
+      - do_term_curie
+      - mod_entity_id
+      - negated
+      - evidence_curies
+      - evidence_code_curies
+      - reference_curie
+      - annotation_type_name
+      - with_gene_curies
+      - disease_qualifier_names
+      - condition_relation_dtos
+      - genetic_sex_name
+      - note_dtos
+      - data_provider
+      - secondary_data_provider
+      - disease_genetic_modifier_curie
+      - disease_genetic_modifier_relation_name
+
   GeneDiseaseAnnotation:
     description: >-
       An annotation asserting an association between a gene and a disease
@@ -279,6 +303,14 @@ classes:
           vocabulary term from the 'Gene disease relations' vocabulary
         required: true
         range: VocabularyTerm
+
+  GeneDiseaseAnnotationDTO:
+    is_a: DiseaseAnnotationDTO
+    description: >-
+      Ingest class for an association between a gene and a disease
+    slots:
+      - gene_curie
+      - sgd_strain_background_curie
 
   AlleleDiseaseAnnotation:
     description: >-
@@ -306,6 +338,16 @@ classes:
         range: Gene
       asserted_genes:
         required: false
+
+  AlleleDiseaseAnnotationDTO:
+    is_a: DiseaseAnnotationDTO
+    description: >-
+      Ingest class for an association between an allele and a disease
+    slots:
+      - allele_curie
+      - inferred_gene_curie
+      - asserted_gene_curies
+
 
   AGMDiseaseAnnotation:
     description: >-
@@ -342,6 +384,17 @@ classes:
         required: false
       asserted_allele:
         required: false
+
+  AGMDiseaseAnnotationDTO:
+    is_a: DiseaseAnnotationDTO
+    description: >-
+      Ingest class for an association between an AGM and a disease
+    slots:
+      - agm_curie
+      - inferred_gene_curie
+      - asserted_gene_curies
+      - inferred_allele_curie
+      - asserted_allele_curie
 
   ExperimentalCondition:
     is_a: AuditedObject
@@ -403,6 +456,21 @@ classes:
           chemcial used in conjunction with 'chemical condition'.
         range: ChemicalTerm
 
+  ExperimentalConditionDTO:
+    is_a: AuditedObjectDTO
+    description: >-
+      Ingest class for describing the environmental context in which an
+      experiment is carried out
+    slots:
+      - condition_class_curie
+      - condition_id_curie
+      - condition_free_text
+      - condition_quantity
+      - condition_anatomy_curie
+      - condition_gene_ontology_curie
+      - condition_taxon_curie
+      - condition_chemical_curie
+
 
   ConditionRelation:
     is_a: AuditedObject
@@ -432,6 +500,22 @@ classes:
         required: true
         multivalued: false
 
+  ConditionRelationDTO:
+    is_a: AuditedObjectDTO
+    description: >-
+      Ingest class for the pairing of an experimental condition relation with
+      a list of one or more conditions
+    slots:
+      - handle
+      - reference_curie
+      - condition_relation_type_name
+      - condition_dtos
+    slot_usage:
+      condition_relation_type_name:
+        required: true
+      condition_dtos:
+        required: true
+
 ## ------------
 ## SLOTS
 ## ------------
@@ -444,16 +528,35 @@ slots:
       The type of annotation classified according to curation method. Submitted
       value should be a vocabulary term from the 'Annotation types' vocabulary
 
+  annotation_type_name:
+    description: >-
+      Name of the VocabularyTerm describing the annotation type
+    domain: DiseaseAnnotationDTO
+    range: string
+
   asserted_allele:
     description: >-
       The allele to which something is manually asserted to be associated.
     range: Allele
+
+  asserted_allele_curie:
+    description: >-
+      Curie of the allele to which something is manually asserted to be
+      associated
+    range: string
 
   asserted_genes:
     singular_name: asserted_gene
     description: >-
       The gene(s) to which something is manually asserted to be associated.
     range: Gene
+    multivalued: true
+
+  asserted_gene_curies:
+    description: >-
+      Curies of the gene(s) to which something is manually asserted to be
+      associated
+    range: string
     multivalued: true
 
   condition_anatomy:
@@ -466,17 +569,33 @@ slots:
       - FBbt
       - GO
 
+  condition_anatomy_curie:
+    description: Curie of AnatomicalTerm associated with condition
+    domain: ExperimentalConditionDTO
+    range: string
+
   condition_chemical:
     domain: ExperimentalCondition
-    range: OntologyTerm                     # Update to Chemical if such a class is instantiated
+    range: ChemicalTerm
     values_from:
       - CHEBI
       - WBMol
+
+  condition_chemical_curie:
+    description: Curie of ChemicalTerm associated with condition
+    domain: ExperimentalConditionDTO
+    range: string
 
   condition_class:
     required: true
     domain: ExperimentalCondition
     range: ZECOTerm
+
+  condition_class_curie:
+    description: Curie of ZECOTerm describing condition class
+    domain: ExperimentalConditionDTO
+    range: string
+    required: true
 
   condition_free_text:
     description: >-
@@ -489,9 +608,20 @@ slots:
     domain: ExperimentalCondition
     range: GOTerm
 
+  condition_gene_ontology_curie:
+    description: Curie of GOTerm associated with condition
+    domain: ExperimentalConditionDTO
+    range: string
+
   condition_id:
     domain: ExperimentalCondition
     range: ExperimentalConditionOntologyTerm
+
+  condition_id_curie:
+    description: Curie of ExperimentalConditionOntologyTerm describing
+      condition
+    domain: ExperimentalConditionDTO
+    range: string
 
   condition_quantity:
     domain: ExperimentalCondition
@@ -504,8 +634,19 @@ slots:
     domain: ConditionRelation
     range: VocabularyTerm
 
+  condition_relation_type_name:
+    description: >-
+      Name of VocabularyTerm from 'Condition relation types' vocabulary
+    domain: ConditionRelationDTO
+    range: string
+    required: true
+
   condition_relations:
     range: ConditionRelation
+    multivalued: true
+
+  condition_relation_dtos:
+    range: ConditionRelationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true
@@ -523,27 +664,32 @@ slots:
     domain: ExperimentalCondition
     range: NCBITaxonTerm
 
+  condition_taxon_curie:
+    description: Curie of NCBITaxonTerm associated with condition
+    domain: ExperimentalConditionDTO
+    range: string
+
   conditions:
     range: ExperimentalCondition
     multivalued: true
+
+  condition_dtos:
+    domain: ConditionRelationDTO
+    range: ExperimentalConditionDTO
+    multivalued: true
+    required: true
     inlined: true
     inlined_as_list: true
-
-  disease_annotation_curie:
-    description: >-
-      The Alliance-minted curie (unique identifier) for the disease annotation of the form:
-      AGRKB:100123456789012 (class code: 100). This is not required upon ingest
-      from DQM disease annotation file submissions to the persistent store, but will
-      be generated Alliance-side post-ingest with the MaTI system.
-    range: uriorcurie
-    required: false
-    identifier: false
-    multivalued: false
 
   disease_genetic_modifier:
     description: >-
       Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.
     required: false
+
+  disease_genetic_modifier_curie:
+    description: Curie of BiologcalEntity that modifies the disease model
+    domain: DiseaseAnnotationDTO
+    range: string
 
   disease_genetic_modifier_relation:
     description: >-
@@ -551,6 +697,13 @@ slots:
       Submitted value should be a vocabulary term from the 'Disease genetic
       modifiers' vocabulary
     range: VocabularyTerm
+
+  disease_genetic_modifier_relation_name:
+    description: >-
+      Name of the VocabularyTerm from the 'Disease genetic modifiers' vocabulary
+      that describes how the genetic modifier modifies the disease model.
+    domain: DiseaseAnnotationDTO
+    range: string
 
   disease_qualifiers:
     description: >-
@@ -560,11 +713,23 @@ slots:
     multivalued: true
     range: VocabularyTerm
 
+  disease_qualifier_names:
+    description: >-
+      Names of terms from the 'Disease qualifiers' vocabulary
+    domain: DiseaseAnnotationDTO
+    range: string
+    multivalued: true
+
   genetic_sex:
     description: >-
       Submitted value should be a vocabulary term from the 'Genetic sexes'
       vocabulary
     range: VocabularyTerm
+
+  genetic_sex_name:
+    description: Name of term from the 'Genetic sexes' vocabulary
+    domain: DiseaseAnnotationDTO
+    range: string
 
   handle:
     description: >-
@@ -577,10 +742,22 @@ slots:
       The gene to which something is inferred to be associated.
     range: Gene
 
+  inferred_gene_curie:
+    description: >-
+      Curie of gene to which something is inferred to be associated via an
+      automated pipeline
+    range: string
+
   inferred_allele:
     description: >-
       The allele to which something is inferred to be associated.
     range: Allele
+
+  inferred_allele_curie:
+    description: >-
+      Curie of allele to which something is inferred to be associated via an
+      automated pipeline
+    range: string
 
   phenotype_term:
     range: PhenotypeTerm
@@ -588,8 +765,31 @@ slots:
   sgd_strain_background:
     range: AffectedGenomicModel
 
+  sgd_strain_background_curie:
+    description: Curie of SGD strain background AGM
+    domain: GeneDiseaseAnnotationDTO
+    range: string
+
   with:
     description: >-
       http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/#with-or-from-column-8
     range: Gene
     multivalued: true
+
+  with_gene_curies:
+    description: >-
+      http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/#with-or-from-column-8
+    range: string
+    multivalued: true
+
+  disease_relation_name:
+    description: Name of term from 'Disease Relation Vocabulary' vocabulary
+    required: true
+    domain: DiseaseAnnotationDTO
+    range: string
+
+  do_term_curie:
+    description: Curie of DOTerm describing the disease
+    domain: DiseaseAnnotationDTO
+    range: string
+    required: true

--- a/model/schema/reference.yaml
+++ b/model/schema/reference.yaml
@@ -338,6 +338,11 @@ slots:
     domain: Reference
     range: string
 
+  reference_curie:
+    description:
+      External reference curie used for ingest
+    range: string
+
   reference_curies:
     description: >-
       External reference curies used for ingest

--- a/model/schema/reference.yaml
+++ b/model/schema/reference.yaml
@@ -102,7 +102,7 @@ classes:
   PersonalCommunication:
     aliases: ["person_evidence"]
     is_a: InformationContentEntity
-    description: >- 
+    description: >-
       a piece of information that is used to support an assertion or annotation, where the information
       comes from a person other than the author of the assertion or annotation, or the author of the reference.
     slot_usage:
@@ -113,12 +113,12 @@ classes:
     description: >-
       Medical Subject Headings information coming from PubMed.
     notes: >-
-      In the literature database, the table is named mesh_details. 
+      In the literature database, the table is named mesh_details.
       In the literature API, the field is named mesh_terms.
     aliases: [ 'mesh_details', 'mesh_terms' ]
     slots:
-      - mesh_detail_id 
-      - reference_id 
+      - mesh_detail_id
+      - reference_id
       - heading_term
       - qualifier_term
     slot_usage:
@@ -131,6 +131,12 @@ slots:
   evidence:
     description: >-
     range: InformationContentEntity
+    multivalued: true
+
+  evidence_curies:
+    description: >-
+      Curies of InformationContentEntity objects given as evidence
+    range: string
     multivalued: true
 
   reference_id:
@@ -221,7 +227,7 @@ slots:
     range: string
     close_mappings:
       - WIKIDATA_PROPERTY:P304
-    
+
   plain_language_abstract:
     description: >-
       Lay person, readable version of the abstract.
@@ -275,7 +281,7 @@ slots:
       editable at Alliance.
     multivalued: true
     range: string
-  
+
   language:
     description: Language of the reference.  Aggregation of PubMed and FlyBase,
       editable at Alliance.
@@ -292,7 +298,7 @@ slots:
   authors:
     description: >-
       Ordered author entities for this publication.  An Author is associated
-      with only one publication.  A Person can be associated with multiple 
+      with only one publication.  A Person can be associated with multiple
       publications.
     multivalued: true
     domain: Reference
@@ -330,6 +336,12 @@ slots:
       From PubMed otherwise from Mod or manual reference creation.
     multivalued: false
     domain: Reference
+    range: string
+
+  reference_curies:
+    description: >-
+      External reference curies used for ingest
+    multivalued: true
     range: string
 
 enums:

--- a/model/schema/variation.yaml
+++ b/model/schema/variation.yaml
@@ -136,6 +136,9 @@ classes:
 
 slots:
 
+  variant_curie:
+    range: string
+
   variant_status:
     description: >-
     required: false # should this default to "public?"

--- a/test/data/agm_test.json
+++ b/test/data/agm_test.json
@@ -3,12 +3,12 @@
   "agm_ingest_set": [
     {
       "curie": "ZFIN:ZDB-FISH-200601-1",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false,
       "name": "TL + MO1-hars",
-      "synonyms": [
+      "synonym_dtos": [
         {
           "name": "test",
           "internal": false
@@ -21,20 +21,20 @@
       "secondary_identifiers": [
         "ZFIN:ZDB-FISH-123456-1"
       ],
-      "references": [],
-      "sequence_targeting_reagents": [
+      "reference_curies": [],
+      "sequence_targeting_reagent_curies": [
         "ZFIN:ZDB-MRPHLNO-191104-1"
       ],
-      "subtype": "fish"
+      "subtype_name": "fish"
     },
     {
       "curie": "ZFIN:ZDB-FISH-150901-28778",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false,
       "name": "pax2a<sup>tb21/tb21</sup>",
-      "synonyms": [
+      "synonym_dtos": [
         {
           "name": "test",
           "internal": false
@@ -47,15 +47,15 @@
       "secondary_identifiers": [
         "ZFIN:ZDB-FISH-123456-1"
       ],
-      "references": [],
-      "components": [
+      "reference_curies": [],
+      "component_dtos": [
         {
-          "has_allele": "ZFIN:ZDB-ALT-980203-1593",
+          "allele_curie": "ZFIN:ZDB-ALT-980203-1593",
           "internal": false,
-          "zygosity": "GENO:0000136"
+          "zygosity_curie": "GENO:0000136"
         }
       ],
-      "subtype": "fish"
+      "subtype_name": "fish"
     }
   ]
 }

--- a/test/data/allele_association_ingest_test.json
+++ b/test/data/allele_association_ingest_test.json
@@ -7,137 +7,137 @@
       "symbol": "a83",
       "internal": false,
       "obsolete": false,
-      "taxon": "NCBITaxon:6239",
+      "taxon_curie": "NCBITaxon:6239",
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002",
-      "in_collection": "Million Mutations Project",
-      "inheritance_mode": "semi-dominant",
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002",
+      "in_collection_name": "Million_Mutation_Project",
+      "inheritance_mode_name": "semi-dominant",
       "is_extinct": false,
-      "sequencing_status": "sequenced"
+      "sequencing_status_name": "sequenced"
     }
   ],
   "allele_gene_association_ingest_set": [
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "RO:0001025",
-      "object": "WB:WBGene00000001",
-      "evidence_code": "ECO:0000006",
-      "evidence": [
+      "allele_curie": "WB:WBVar00000001",
+      "ro_term_curie": "RO:0001025",
+      "gene_curie": "WB:WBGene00000001",
+      "evidence_code_curie": "ECO:0000006",
+      "evidence_curies": [
         "PMID:11231512"
       ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     }
   ],
   "allele_transcript_association_ingest_set": [
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "RO:0001025",
-      "object": "WB:WBTranscript00000001",
-      "evidence_code": "ECO:0000006",
-      "evidence": [
+      "allele_curie": "WB:WBVar00000001",
+      "ro_term_curie": "RO:0001025",
+      "transcript_curie": "WB:WBTranscript00000001",
+      "evidence_code_curie": "ECO:0000006",
+      "evidence_curies": [
         "PMID:11231512"
       ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     }
   ],
   "allele_protein_association_ingest_set": [
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "RO:0001025",
-      "object": "WB:WBProtein00000001",
-      "evidence_code": "ECO:0000006",
-      "evidence": [
+      "allele_curie": "WB:WBVar00000001",
+      "ro_term_curie": "RO:0001025",
+      "protein_curie": "WB:WBProtein00000001",
+      "evidence_code_curie": "ECO:0000006",
+      "evidence_curies": [
         "PMID:11231512"
       ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     }
   ],
   "allele_origin_association_ingest_set": [
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "introduced_in",
-      "object": "WB:WBStrain00000001",
+      "allele_curie": "WB:WBVar00000001",
+      "predicate_name": "introduced_in",
+      "agm_curie": "WB:WBStrain00000001",
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     }
   ],
   "allele_construct_association_ingest_set": [
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "RO:0001019",
-      "object": "WB:WBConstruct00000001",
-      "evidence_code": "ECO:0000006",
-      "evidence": [
+      "allele_curie": "WB:WBVar00000001",
+      "ro_term_curie": "RO:0001019",
+      "construct_curie": "WB:WBConstruct00000001",
+      "evidence_code_curie": "ECO:0000006",
+      "evidence_curies": [
         "PMID:11231512"
       ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     }
   ],
   "allele_cell_line_association_ingest_set": [
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "carried_by_cell_line",
-      "object": "WB:WBCell00000002",
+      "allele_curie": "WB:WBVar00000001",
+      "predicate_name": "carried_by_cell_line",
+      "cell_line_curie": "WB:WBCell00000002",
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     },
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "has_parent_cell_line",
-      "object": "WB:WBCell00000001",
+      "allele_curie": "WB:WBVar00000001",
+      "predicate_name": "has_parent_cell_line",
+      "cell_line_curie": "WB:WBCell00000001",
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     }
   ],
   "allele_variant_association_ingest_set": [
     {
-      "subject": "WB:WBVar00000001",
-      "predicate": "RO:0001019",
-      "object": "WB:WBVar00000001",
-      "evidence_code": "ECO:0000006",
-      "evidence": [
+      "allele_curie": "WB:WBVar00000001",
+      "ro_term_curie": "RO:0001019",
+      "variant_curie": "WB:WBVar00000001",
+      "evidence_code_curie": "ECO:0000006",
+      "evidence_curies": [
         "PMID:11231512"
       ],
       "internal": false,
       "obsolete": false,
       "date_created": "2015-04-09T10:15:30+00:00",
       "date_updated": "2022-07-11T13:12:51+00:00",
-      "created_by": "WB:WBPerson002314",
-      "updated_by": "WB:WBPerson010002"
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
     }
   ]
 }

--- a/test/data/allele_association_ingest_test.json
+++ b/test/data/allele_association_ingest_test.json
@@ -14,8 +14,7 @@
       "updated_by_curie": "WB:WBPerson010002",
       "in_collection_name": "Million_Mutation_Project",
       "inheritance_mode_name": "semi-dominant",
-      "is_extinct": false,
-      "sequencing_status_name": "sequenced"
+      "is_extinct": false
     }
   ],
   "allele_gene_association_ingest_set": [

--- a/test/data/allele_slot_annotation_ingest_test.json
+++ b/test/data/allele_slot_annotation_ingest_test.json
@@ -1,77 +1,86 @@
 {
   "linkml_version": "1.3.0",
-  "allele_mutation_type_annotation_ingest_set": [
+  "allele_ingest_set": [
     {
-      "single_allele": "WB:WBVar00000001",
-      "mutation_type": "insertion",
-      "evidence": [
-        "PMID:11231512"
+      "curie": "WB:WBVar00000001",
+      "name": "variation 1",
+      "symbol": "a83",
+      "internal": false,
+      "obsolete": false,
+      "taxon_curie": "NCBITaxon:6239",
+      "date_created": "2015-04-09T10:15:30+00:00",
+      "date_updated": "2022-07-11T13:12:51+00:00",
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002",
+      "in_collection_name": "Million_Mutation_Project",
+      "inheritance_mode_name": "semi-dominant",
+      "is_extinct": false,
+      "sequencing_status_name": "sequenced",
+      "allele_mutation_type_dtos": [
+        {
+          "mutation_type_curies": [
+            "SO:0000180"
+          ],
+          "evidence_curies": [
+            "PMID:11231512"
+          ],
+          "internal": false
+        }
       ],
-      "internal": false
-    }
-  ],
-  "allele_germline_transmission_status_annotation_ingest_set": [
-    {
-      "single_allele": "WB:WBVar00000001",
-      "germline_transmission_status": "germline",
-      "evidence": [
-        "PMID:11231512"
+      "allele_functional_impact_dtos": [
+        {
+          "functional_impact_names": [
+            "loss-of-function"
+          ],
+          "evidence_curies": [
+            "PMID:11231512"
+          ],
+          "internal": false
+        }
       ],
-      "internal": false
-    }
-  ],
-  "allele_functional_impact_annotation_ingest_set": [
-    {
-      "single_allele": "WB:WBVar00000001",
-      "functional_impact": [
-        "loss-of-function"
+      "allele_germline_transmission_status_dto": {
+        "germline_transmission_status_name": "germline",
+        "evidence_curies": [
+          "PMID:11231512"
+        ],
+        "internal": false
+      },
+      "allele_molecular_mutation_dtos": [
+        {
+          "molecular_mutation_names": [
+            "insertion"
+          ],
+          "evidence_curies": [
+            "PMID:11231512"
+          ],
+          "internal": false
+        }
       ],
-      "evidence": [
-        "PMID:11231512"
+      "allele_database_status_dto": {
+        "database_status_name": "public",
+        "evidence_curies": [
+          "PMID:11231512"
+        ],
+        "internal": false
+      },
+      "allele_secondary_id_dtos": [
+        {
+          "secondary_id": "WBVar00000001",
+          "evidence_curies": [
+            "PMID:11231512"
+          ],
+          "internal": false
+        }
       ],
-      "internal": false
-    }
-  ],
-  "allele_molecular_mutation_annotation_ingest_set": [
-    {
-      "single_allele": "WB:WBVar00000001",
-      "molecular_mutations": [
-        "insertion"
-      ],
-      "evidence": [
-        "PMID:11231512"
-      ],
-      "internal": false
-    }
-  ],
-  "allele_database_status_annotation_ingest_set": [
-    {
-      "single_allele": "WB:WBVar00000001",
-      "database_status": "public",
-      "evidence": [
-        "PMID:11231512"
-      ],
-      "internal": false
-    }
-  ],
-  "allele_secondary_id_annotation_ingest_set": [
-    {
-      "single_allele": "WB:WBVar00000001",
-      "secondary_id": "WBVar00000001",
-      "evidence": [
-        "PMID:11231512"
-      ],
-      "internal": false
-    }
-  ],
-  "allele_nomenclature_annotation_ingest_set": [
-    {
-      "single_allele": "WB:WBVar00000001",
-      "nomenclature_event": "named",
-      "evidence": [
-        "PMID:11231512"
-      ],
-      "internal": false
+      "allele_nomenclature_event_dtos": [
+        {
+          "nomenclature_event_name": "named",
+          "evidence_curies": [
+            "PMID:11231512"
+          ],
+          "internal": false
+        }
+      ]
     }
   ]
 }

--- a/test/data/allele_slot_annotation_ingest_test.json
+++ b/test/data/allele_slot_annotation_ingest_test.json
@@ -15,7 +15,6 @@
       "in_collection_name": "Million_Mutation_Project",
       "inheritance_mode_name": "semi-dominant",
       "is_extinct": false,
-      "sequencing_status_name": "sequenced",
       "allele_mutation_type_dtos": [
         {
           "mutation_type_curies": [

--- a/test/data/allele_test.json
+++ b/test/data/allele_test.json
@@ -3,17 +3,17 @@
   "allele_ingest_set": [
     {
       "curie": "ZFIN:ZDB-ALT-130621-1",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false,
       "symbol": "b1219"
     },
     {
       "curie": "ZFIN:ZDB-ALT-130411-947",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false,
       "symbol": "sa11077"
     }

--- a/test/data/disease_agm_test.json
+++ b/test/data/disease_agm_test.json
@@ -2,27 +2,26 @@
   "linkml_version": "1.3.0",
   "disease_agm_ingest_set": [
     {
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0000305"
       ],
-      "disease_annotation_curie": "AGRKB:100123456789014",
-      "single_reference": "PMID:123456",
+      "reference_curie": "PMID:123456",
       "data_provider": "ZFIN",
-      "object": "DOID:9452",
+      "do_term_curie": "DOID:9452",
       "date_created": "ZFIN",
       "date_updated": "ZFIN",
       "internal": false,
-      "subject": "ZFIN:ZDB-FISH-180912-16",
-      "inferred_gene": "ZFIN:ZDB-GENE-060503-338",
-      "predicate": "is_model_of",
-      "condition_relations": [
+      "agm_curie": "ZFIN:ZDB-FISH-180912-16",
+      "inferred_gene_curie": "ZFIN:ZDB-GENE-060503-338",
+      "disease_relation_name": "is_model_of",
+      "condition_relation_dtos": [
         {
-          "condition_relation_type": "has_condition",
+          "condition_relation_type_name": "has_condition",
           "internal": false,
-          "conditions": [
+          "condition_dtos": [
             {
               "condition_free_text": "Bacterial strain HB101",
-              "condition_class": "ZECO:0000104",
+              "condition_class_curie": "ZECO:0000104",
               "internal": false
             }
           ]

--- a/test/data/disease_allele_test.json
+++ b/test/data/disease_allele_test.json
@@ -2,20 +2,19 @@
   "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
-      "disease_annotation_curie": "AGRKB:100123456789013",
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0000305"
       ],
-      "single_reference": "PMID:123456",
+      "reference_curie": "PMID:123456",
       "data_provider": "ZFIN",
-      "subject": "ZFIN:ZDB-ALT-001122-1",
-      "predicate": "is_implicated_in",
-      "object": "DOID:0001234",
-      "asserted_genes": [
+      "allele_curie": "ZFIN:ZDB-ALT-001122-1",
+      "disease_relation_name": "is_implicated_in",
+      "do_term_curie": "DOID:0001234",
+      "asserted_gene_curies": [
         "ZFIN:ZDB-GENE-060503-338"
       ],
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false
     }
   ]

--- a/test/data/disease_gene_test.json
+++ b/test/data/disease_gene_test.json
@@ -2,18 +2,17 @@
   "linkml_version": "1.3.0",
   "disease_gene_ingest_set": [
     {
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0000305"
       ],
-      "disease_annotation_curie": "AGRKB:100123456789014",
-      "single_reference": "PMID:123456",
+      "reference_curie": "PMID:123456",
       "data_provider": "ZFIN",
-      "object": "DOID:0001234",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "do_term_curie": "DOID:0001234",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false,
-      "subject": "ZFIN:ZDB-GENE-001122-1",
-      "predicate": "is_implicated_in"
+      "gene_curie": "ZFIN:ZDB-GENE-001122-1",
+      "disease_relation_name": "is_implicated_in"
     }
   ]
 }

--- a/test/data/fb_disease_test.json
+++ b/test/data/fb_disease_test.json
@@ -2,40 +2,38 @@
   "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
-      "disease_annotation_curie": "AGRKB:100123456789015",
-      "subject": "FB:FBal0000272",
-      "predicate": "is_implicated_in",
-      "object": "DOID:3191",
+      "allele_curie": "FB:FBal0000272",
+      "disease_relation_name": "is_implicated_in",
+      "do_term_curie": "DOID:3191",
       "negated": false,
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0007013"
       ],
-      "single_reference": "FB:FBrf0227496",
-      "annotation_type": "manually_curated",
+      "reference_curie": "FB:FBrf0227496",
+      "annotation_type_name": "manually_curated",
       "data_provider": "FB",
-      "created_by": "FB:FB_curator",
+      "created_by_curie": "FB:FB_curator",
       "date_created": "2022-01-12T09:57:42-05:00",
-      "updated_by": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator",
       "internal": false,
       "date_updated": "2022-01-12T09:57:42-05:00"
     }
   ],
   "disease_gene_ingest_set": [
     {
-      "disease_annotation_curie": "AGRKB:100123456789016",
-      "subject": "FB:FBgn0000047",
-      "predicate": "is_implicated_in",
-      "object": "DOID:422",
+      "gene_curie": "FB:FBgn0000047",
+      "disease_relation_name": "is_implicated_in",
+      "do_term_curie": "DOID:422",
       "negated": false,
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0007013"
       ],
-      "single_reference": "FB:FBrf0211153",
-      "annotation_type": "manually_curated",
+      "reference_curie": "FB:FBrf0211153",
+      "annotation_type_name": "manually_curated",
       "data_provider": "FB",
-      "created_by": "FB:FB_curator",
+      "created_by_curie": "FB:FB_curator",
       "date_created": "2022-01-12T09:57:42-05:00",
-      "updated_by": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator",
       "internal": false,
       "date_updated": "2022-01-12T09:57:42-05:00"
     }

--- a/test/data/gene_test.json
+++ b/test/data/gene_test.json
@@ -3,18 +3,18 @@
   "gene_ingest_set": [
     {
       "curie": "ZFIN:ZDB-GENE-010226-1",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false,
       "symbol": "gdnfa",
       "name": "glial cell derived neurotrophic factor a",
-      "cross_references": [
+      "cross_reference_dtos": [
         {
           "curie": "ZFIN:ZDB-GENE-010226-1",
-          "created_by": "ZFIN",
+          "created_by_curie": "ZFIN",
           "display_name": "",
-          "updated_by": "ZFIN",
+          "updated_by_curie": "ZFIN",
           "internal": false,
           "page_areas": [
             "gene",
@@ -27,15 +27,15 @@
         },
         {
           "curie": "NCBI_Gene:79379",
-          "created_by": "ZFIN",
-          "updated_by": "ZFIN",
+          "created_by_curie": "ZFIN",
+          "updated_by_curie": "ZFIN",
           "internal": false,
           "page_areas": [],
           "prefix": "NCBI_Gene",
           "display_name": ""
         }
       ],
-      "gene_type": "SO:0001217"
+      "gene_type_curie": "SO:0001217"
     }
   ]
 }

--- a/test/data/invalid/allele_invalid.json
+++ b/test/data/invalid/allele_invalid.json
@@ -4,15 +4,15 @@
     {
       "additional_propertie": "this is invalid",
       "curie": "ZFIN:ZDB-ALT-123456-1",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN"
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN"
     },
     {
       "curi": "ZFIN:ZDB-ALT-123456-2",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN"
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN"
     }
   ]
 }

--- a/test/data/invalid/disease_allele_invalid.json
+++ b/test/data/invalid/disease_allele_invalid.json
@@ -2,18 +2,18 @@
   "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
-      "evidence_code": [
+      "evidence_code_curie": [
         "TAS"
       ],
-      "single_reference": "PMID:0012345",
+      "reference_curie": "PMID:0012345",
       "data_provider": [
         "ZFIN"
       ],
-      "subjectTO": "ZFIN:ZDB-ALT-001122-1",
-      "predicate": "is model of",
-      "object": "DOID:0001234",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN"
+      "allele_curie": "ZFIN:ZDB-ALT-001122-1",
+      "disease_relation_name": "is model of",
+      "do_term_curie": "DOID:0001234",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN"
     }
   ]
 }

--- a/test/data/invalid/missing_version.json
+++ b/test/data/invalid/missing_version.json
@@ -2,12 +2,12 @@
   "agm_ingest_set": [
     {
       "curie": "ZFIN:ZDB-FISH-200601-1",
-      "taxon": "NCBITaxon:7955",
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "taxon_curie": "NCBITaxon:7955",
+      "created_by_curie": "ZFIN",
+      "updated_by_curie": "ZFIN",
       "internal": false,
       "name": "TL + MO1-hars",
-      "synonyms": [
+      "synonym_dtos": [
         {
           "name": "test",
           "internal": false
@@ -20,11 +20,11 @@
       "secondary_identifiers": [
         "ZFIN:ZDB-FISH-123456-1"
       ],
-      "references": [],
-      "sequence_targeting_reagents": [
+      "reference_curies": [],
+      "sequence_targeting_reagent_curies": [
         "ZFIN:ZDB-MRPHLNO-191104-1"
       ],
-      "subtype": "fish"
+      "subtype_name": "fish"
     }
   ]
 }

--- a/test/data/sgd_disease_test.json
+++ b/test/data/sgd_disease_test.json
@@ -2,29 +2,28 @@
   "linkml_version": "1.3.0",
   "disease_gene_ingest_set": [
     {
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0000250",
         "ECO:0000316"
       ],
-      "disease_annotation_curie": "AGRKB:100123456789017",
-      "annotation_type": "manually curated",
-      "single_reference": "PMID:21145416",
+      "annotation_type_name": "manually curated",
+      "reference_curie": "PMID:21145416",
       "data_provider": "SGD",
-      "object": "DOID:10588",
-      "created_by": "SGD",
-      "updated_by": "SGD",
+      "do_term_curie": "DOID:10588",
+      "created_by_curie": "SGD",
+      "updated_by_curie": "SGD",
       "internal": false,
       "date_created": "2018-04-25T14:04:15-00:00",
-      "subject": "SGD:S000001671",
-      "related_notes": [
+      "gene_curie": "SGD:S000001671",
+      "note_dtos": [
         {
           "free_text": "Yeast PXA2 is homologous to human ABCD1 and ABCD2, and has been used to study adrenoleukodystrophy",
-          "note_type": "disease_summary",
+          "note_type_name": "disease_summary",
           "internal": false
         }
       ],
-      "predicate": "is_implicated_in",
-      "with": [
+      "disease_relation_name": "is_implicated_in",
+      "with_gene_curies": [
         "HGNC:61",
         "HGNC:66"
       ]

--- a/test/data/variant_allele_association_test.json
+++ b/test/data/variant_allele_association_test.json
@@ -2,13 +2,13 @@
   "linkml_version": "1.3.0",
   "allele_variant_association_ingest_set": [
     {
-      "created_by": "ZFIN",
-      "updated_by": "ZFIN",
+      "created_by_curie": "ZFIN:curator",
+      "updated_by_curie": "ZFIN:curator",
       "internal": false,
-      "subject": "ZFIN:ZDB-ALT-000412-8",
-      "object": "ZFIN:ZDB-ALT-000412-8",
-      "predicate": "RO:0002525",
-      "evidence": [
+      "allele_curie": "ZFIN:ZDB-ALT-000412-8",
+      "variant_curie": "ZFIN:ZDB-ALT-000412-8",
+      "ro_term_curie": "RO:0002525",
+      "evidence_curies": [
         "ZFIN:ZDB-PUB-010101-1"
       ]
     }

--- a/test/data/wb_disease_test.json
+++ b/test/data/wb_disease_test.json
@@ -2,158 +2,154 @@
   "linkml_version": "1.3.0",
   "disease_allele_ingest_set": [
     {
-      "condition_relations": [
+      "condition_relation_dtos": [
         {
-          "condition_relation_type": "induced_by",
+          "condition_relation_type_name": "induced_by",
           "internal": false,
-          "conditions": [
+          "condition_dtos": [
             {
-              "condition_chemical": "CHEBI:6432",
-              "condition_class": "ZECO:0000111",
+              "condition_chemical_curie": "CHEBI:6432",
+              "condition_class_curie": "ZECO:0000111",
               "internal": false
             },
             {
               "condition_free_text": "Bacterial strain HB101",
-              "condition_class": "ZECO:0000104",
+              "condition_class_curie": "ZECO:0000104",
               "internal": false
             }
           ]
         }
       ],
-      "disease_annotation_curie": "AGRKB:100123456789018",
       "data_provider": "WB",
-      "created_by": "WB:WBPerson324",
+      "created_by_curie": "WB:WBPerson324",
       "date_updated": "2021-09-01T00:00:00+00:00",
-      "related_notes": [
+      "note_dtos": [
         {
           "free_text": "summary statement",
-          "note_type": "disease_summary",
+          "note_type_name": "disease_summary",
           "internal": false
         }
       ],
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0000315",
         "ECO:0007013"
       ],
-      "genetic_sex": "hermaphrodite",
+      "genetic_sex_name": "hermaphrodite",
       "mod_entity_id": "WBDOannot00001032",
-      "updated_by": "WB:WBPerson324",
+      "updated_by_curie": "WB:WBPerson324",
       "internal": false,
       "negated": false,
-      "object": "DOID:11724",
-      "predicate": "is_implicated_in",
-      "single_reference": "PMID:19648295",
-      "subject": "WB:WBVar00087752"
+      "do_term_curie": "DOID:11724",
+      "disease_relation_name": "is_implicated_in",
+      "reference_curie": "PMID:19648295",
+      "allele_curie": "WB:WBVar00087752"
     }
   ],
   "disease_gene_ingest_set": [
     {
-      "condition_relations": [
+      "condition_relation_dtos": [
         {
-          "condition_relation_type": "induced_by",
+          "condition_relation_type_name": "induced_by",
           "internal": false,
-          "conditions": [
+          "condition_dtos": [
             {
-              "condition_chemical": "CHEBI:34910",
-              "condition_class": "ZECO:0000111",
+              "condition_chemical_curie": "CHEBI:34910",
+              "condition_class_curie": "ZECO:0000111",
               "internal": false
             }
           ]
         }
       ],
-      "disease_annotation_curie": "AGRKB:100123456789019",
       "data_provider": "WB",
-      "created_by": "WB:WBPerson324",
+      "created_by_curie": "WB:WBPerson324",
       "date_updated": "2021-08-24T00:00:00+00:00",
-      "related_notes": [
+      "note_dtos": [
         {
           "free_text": "summary statement",
-          "note_type": "disease_summary",
+          "note_type_name": "disease_summary",
           "internal": false
         }
       ],
-      "disease_genetic_modifier": "WB:WBStrain00035193",
-      "disease_genetic_modifier_relation": "ameliorated_by",
-      "evidence_codes": [
+      "disease_genetic_modifier_curie": "WB:WBStrain00035193",
+      "disease_genetic_modifier_relation_name": "ameliorated_by",
+      "evidence_code_curies": [
         "ECO:0000315",
         "ECO:0007013"
       ],
-      "genetic_sex": "hermaphrodite",
+      "genetic_sex_name": "hermaphrodite",
       "mod_entity_id": "WBDOannot00001014",
-      "updated_by": "WB:WBPerson324",
+      "updated_by_curie": "WB:WBPerson324",
       "negated": false,
       "internal": false,
-      "object": "DOID:1826",
-      "predicate": "is_implicated_in",
-      "single_reference": "PMID:19648295",
-      "subject": "WB:WBGene00011955"
+      "do_term_curie": "DOID:1826",
+      "disease_relation_name": "is_implicated_in",
+      "reference_curie": "PMID:19648295",
+      "gene_curie": "WB:WBGene00011955"
     }
   ],
   "disease_agm_ingest_set": [
     {
-      "created_by": "WB:WBPerson324",
-      "disease_annotation_curie": "AGRKB:100123456789020",
+      "created_by_curie": "WB:WBPerson324",
       "data_provider": "WB",
       "date_updated": "2019-03-08T00:00:00+00:00",
-      "disease_genetic_modifier": "WB:WBVar00250993",
-      "disease_genetic_modifier_relation": "exacerbated_by",
-      "evidence_codes": [
+      "disease_genetic_modifier_curie": "WB:WBVar00250993",
+      "disease_genetic_modifier_relation_name": "exacerbated_by",
+      "evidence_code_curies": [
         "ECO:0000315",
         "ECO:0007013"
       ],
-      "genetic_sex": "hermaphrodite",
+      "genetic_sex_name": "hermaphrodite",
       "mod_entity_id": "WBDOannot00000109",
-      "updated_by": "WB:WBPerson324",
+      "updated_by_curie": "WB:WBPerson324",
       "internal": false,
-      "object": "DOID:10652",
-      "predicate": "is_model_of",
-      "single_reference": "PMID:19648295",
-      "subject": "WB:WBStrain00005094",
-      "inferred_allele": "WB:WBTransgene00000410"
+      "do_term_curie": "DOID:10652",
+      "disease_relation_name": "is_model_of",
+      "reference_curie": "PMID:19648295",
+      "agm_curie": "WB:WBStrain00005094",
+      "inferred_allele_curie": "WB:WBTransgene00000410"
     },
     {
-      "condition_relations": [
+      "condition_relation_dtos": [
         {
-          "condition_relation_type": "ameliorated_by",
+          "condition_relation_type_name": "ameliorated_by",
           "internal": false,
-          "conditions": [
+          "condition_dtos": [
             {
-              "condition_chemical": "CHEBI:30052",
-              "condition_class": "ZECO:0000111",
+              "condition_chemical_curie": "CHEBI:30052",
+              "condition_class_curie": "ZECO:0000111",
               "internal": false
             },
             {
-              "condition_chemical": "WB:WBMol:00004976",
-              "condition_class": "ZECO:0000111",
+              "condition_chemical_curie": "WB:WBMol:00004976",
+              "condition_class_curie": "ZECO:0000111",
               "internal": false
             }
           ]
         }
       ],
-      "created_by": "WB:WBPerson324",
-      "disease_annotation_curie": "AGRKB:100123456789021",
+      "created_by_curie": "WB:WBPerson324",
       "data_provider": "WB",
       "date_updated": "2017-05-22T00:00:00+00:00",
-      "related_notes": [
+      "note_dtos": [
         {
           "free_text": "Mutations in human dystrophin are associated with the Duchenne and Becker types of muscular dystrophy, that affect skeletal muscles used for movement, and heart (cardiac) muscle; the genetic model for progressive myopathy in C. elegans is a mutant of the elegans dystrophin ortholog, dys-1, combined with a mutation in hlh-1, the MyoD ortholog, (dys-1(cx18);hlh-1(cc561ts), these animals display time-dependent muscle degeneration; a screen of approximately 1000 compounds on the dys-1(cx18),hlh-1(cc561) model, identified several substances that ameliorated the dystrophic phenotype, with the top hits being the sulfonamides, methazolamide (MTZ) and dichlorphenamide (DCPM), known inhibitors of carbonic anydrase (CA) enymes; knock-down of the elegans CA ortholog, cah-4, via RNAi interference, significantly reduced muscle degeneration in the dys-1(cx18),hlh-1(cc561) strain; further, the effects of MTZ and DCPM have been validated in the mdx mouse model for Duchenne muscular dystrophy (DMD).",
-          "note_type": "disease_summary",
+          "note_type_name": "disease_summary",
           "internal": false
         }
       ],
-      "evidence_codes": [
+      "evidence_code_curies": [
         "ECO:0000315",
         "ECO:0007013"
       ],
-      "genetic_sex": "hermaphrodite",
+      "genetic_sex_name": "hermaphrodite",
       "mod_entity_id": "WBDOannot00000110",
-      "updated_by": "WB:WBPerson324",
+      "updated_by_curie": "WB:WBPerson324",
       "internal": false,
-      "object": "DOID:11723",
-      "predicate": "is_model_of",
-      "single_reference": "PMID:19648295",
-      "subject": "WB:WBStrain00024340",
-      "asserted_allele": "WB:WBVar00054722"
+      "do_term_curie": "DOID:11723",
+      "disease_relation_name": "is_model_of",
+      "reference_curie": "PMID:19648295",
+      "agm_curie": "WB:WBStrain00024340",
+      "asserted_allele_curie": "WB:WBVar00054722"
     }
   ]
 }


### PR DESCRIPTION
As a result of a discussion within the A-Team, we believe the best way forward or the LinkML model is to separate ingest modelling from database / Java code modelling.  This is an initial proposed remodel for the classes currently ingested by the A-Team's curation database.  This accurately represents both our ingest DTO classes and our entity classes (used to generate the database schema via Hibernate).  It allows for fields to be required in the database but not in the ingest files, and allows both forward- and back-references to be explicitly described in the LinkML model.  

@oblodgett, @chris-grove  - Any initial feedback before taking this to the wider modelling group?