### PR TITLE
Miscellaneous updates for A-Team Dec 2022

### DIFF
--- a/model/schema/agent.yaml
+++ b/model/schema/agent.yaml
@@ -17,6 +17,7 @@ emit_prefixes:
 imports:
   - linkml:types
   - core
+  - allianceMember
 
 prefixes:
   alliance: 'http://alliancegenome.org/'

--- a/model/schema/agent.yaml
+++ b/model/schema/agent.yaml
@@ -66,6 +66,7 @@ classes:
       - old_emails
       - mod_entity_id
       - unique_id
+      - affiliated_alliance_member
     exact_mappings:
       - schema:person
       - foaf:Person
@@ -87,6 +88,11 @@ classes:
         required: true
 
 slots:
+
+  affiliated_alliance_member:
+    description: The Alliance Member the person is affiliated with
+    domain: Person
+    range: AllianceMember
 
   orcid:
     description:  Open Researcher and Contributor ID

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -843,11 +843,13 @@ slots:
     description: Germline transmission status for a given allele
     domain: Allele
     range: AlleleGermlineTransmissionStatusSlotAnnotation
+    multivalued: false
 
   allele_germline_transmission_status_dto:
     domain: AlleleDTO
     range: AlleleGermlineTransmissionStatusSlotAnnotationDTO
     inlined: true
+    multivalued: false
 
   germline_transmission_status:
     description: >-
@@ -1056,6 +1058,7 @@ slots:
     description: Notes for a given allele
     domain: Allele
     range: AlleleNoteSlotAnnotation
+    multivalued: true
 
   allele_note_dtos:
     is_a: note_dtos

--- a/model/schema/controlledVocabulary.yaml
+++ b/model/schema/controlledVocabulary.yaml
@@ -38,6 +38,7 @@ slots:
     description: >-
       Free text synonym(s) of a term, used for controlled vocabulary terms; this is distinct from the
       'synonyms' slot which has a range of a Synonym class object.
+    domain: VocabularyTerm
     range: string
     multivalued: true
 

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -517,12 +517,6 @@ slots:
       The cateogry of pages the resource in the context of the URL associated with the crossReference
       provides.  Equivalent to the 'page' attribute in the Alliance resourceDescriptor file.
 
-  private_comment:
-    description: >-
-      A private explanatory note from curators about some entity, for internal
-      use only.
-    range: string
-
   uncertain:
     description: >-
       If set to true, then the related entity is uncertain.


### PR DESCRIPTION
- Add affiliated_alliance_member slot to Person class
- Make 'allele_notes' slot multivalued
- removed 'private_comment' slot
- Make allele_germline_transmission_status (and dto slot) single-valued
- Set domain of 'text_synonyms' to VocabularyTerm