### PR TITLE
Make subtype_name required for AGM submissions

### DIFF
--- a/model/schema/affectedGenomicModel.yaml
+++ b/model/schema/affectedGenomicModel.yaml
@@ -101,6 +101,7 @@ slots:
       / fish
     domain: AffectedGenomicModelDTO
     range: string
+    required: true
 
   components:
     singular_name: component


### PR DESCRIPTION
'subtype' is already a required field, but the corresponding DTO field had not been set as being required