### PR TITLE
full_name and systematic_name DTOs should be optional for genes

### DIFF
--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -207,7 +207,7 @@ slots:
     domain: GeneDTO
     range: FullNameSlotAnnotationDTO
     multivalued: false
-    required: true
+    required: false
     inlined: true
 
   gene_systematic_name:
@@ -224,7 +224,7 @@ slots:
     domain: GeneDTO
     range: SystematicNameSlotAnnotationDTO
     multivalued: false
-    required: true
+    required: false
     inlined: true
 
   gene_synonyms:


### PR DESCRIPTION
I think that these changes to the DTOs mirror specs for the corresponding non-DTO objects.
1. Not all fly genes have a systematic name - about half of D. melanogaster genes have not been mapped to the genome.
2. Not all fly genes have a full name. Genes only known by a systematic name do not have full names. In another scenario, the gene symbol and full_name are identical.