### PR TITLE
simplify docker with make commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,13 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     build-essential
 
+
 # install poetry - respects $POETRY_VERSION & $POETRY_HOME
 RUN curl -sSL https://install.python-poetry.org | python
 
 # copy project requirement files here to ensure they will be cached.
 WORKDIR src
+COPY Makefile pyproject.toml poetry.lock README.md .
+COPY . .
 
+CMD poetry install && make test

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ gen-java: $(patsubst %, $(TARGET_DIR)/java/%.java, $(SCHEMA_NAMES))
 $(TARGET_DIR)/java/%.java: $(SCHEMA_DIR)/%.yaml tdir-java
 	poetry run gen-java $(JAVA_GEN_OPTS)  $<
 
-run-tests: 
+run-tests:
 	docker build -t agr_curation_schema .
 	docker run -i -t --name agr_curation_schema agr_curation_schema
 

--- a/Makefile
+++ b/Makefile
@@ -231,3 +231,12 @@ gen-java: $(patsubst %, $(TARGET_DIR)/java/%.java, $(SCHEMA_NAMES))
 
 $(TARGET_DIR)/java/%.java: $(SCHEMA_DIR)/%.yaml tdir-java
 	poetry run gen-java $(JAVA_GEN_OPTS)  $<
+
+run-tests: 
+	docker build -t agr_curation_schema .
+	docker run -i -t --name agr_curation_schema agr_curation_schema
+
+remove-container:
+	docker stop agr_curation_schema
+	docker rm agr_curation_schema
+

--- a/README.md
+++ b/README.md
@@ -280,35 +280,14 @@ make test
 
 ## Alternate development environment - Using Docker
 
-1) install docker
-2) build the docker image
+1) remove containers if exist
 ```bash
-docker build -t agr_curation_schema .
+make remove-container
 ```
-3) run the docker image
+2) build and run the tests in the container
 ```bash
-docker run -t -d --name agr_curation_schema agr_curation_schema -v .:/agr_curation_schema 
-```
-# TODO: add docker cp command example here.
-# TODO: script the docker spin up.
-4) invade the running container
-```bash
-docker exec -it agr_curation_schema /bin/bash
-```
-5) clone the repo
-```bash
-git clone https://github.com/alliance-genome/agr_curation_schema
-cd agr_curation_schema
-git checkout my_branch_to_run_tests
-```
-6) install the project
-```bash
-poetry install
-```
-7) run the tests
-```bash
-make test
-```
+make run-tests
+````
 
 ## Alternate alternate test environment - just use pipx on MacOS
 1) install pipx

--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ make remove-container
 ```bash
 make run-tests
 ````
+This will spin up and run the tests in a container.  If your tests fail, then run `make remove-container`, edit
+the files or schema as necessary, and then run `make run-tests` again.
+
+3) remove the container when done
+```bash
+make remove-container
+```
 
 ## Alternate alternate test environment - just use pipx on MacOS
 1) install pipx


### PR DESCRIPTION
from a modified agr_curation_schemas checkout:
`make run-tests` will now:
- build and run a docker container
- install a poetry environment in the docker container
- run the tests using local files.

if the tests fail, you can always
`make remove-container`, edit the necessary files, and run `make run-tests` again 
