### PR TITLE
A-Team updates: new phenotypes, multiple genetic modifiers, etc.

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -233,9 +233,12 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "disease_genetic_modifier_curie": {
+                "disease_genetic_modifier_curies": {
                     "description": "Curie of BiologcalEntity that modifies the disease model",
-                    "type": "string"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "disease_genetic_modifier_relation_name": {
                     "description": "Name of the VocabularyTerm that describes how the genetic modifier modifies the disease model, selected from the 'Disease genetic modifier relations' Vocabulary.",
@@ -2262,9 +2265,12 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "disease_genetic_modifier_curie": {
+                "disease_genetic_modifier_curies": {
                     "description": "Curie of BiologcalEntity that modifies the disease model",
-                    "type": "string"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "disease_genetic_modifier_relation_name": {
                     "description": "Name of the VocabularyTerm that describes how the genetic modifier modifies the disease model, selected from the 'Disease genetic modifier relations' Vocabulary.",
@@ -10259,9 +10265,12 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "disease_genetic_modifier_curie": {
+                "disease_genetic_modifier_curies": {
                     "description": "Curie of BiologcalEntity that modifies the disease model",
-                    "type": "string"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "disease_genetic_modifier_relation_name": {
                     "description": "Name of the VocabularyTerm that describes how the genetic modifier modifies the disease model, selected from the 'Disease genetic modifier relations' Vocabulary.",

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -11969,7 +11969,7 @@
         },
         "HPTerm": {
             "additionalProperties": false,
-            "description": "A phenotype ontology term from the Human Phenotype (MP) Ontology. PURL: http://purl.obolibrary.org/obo/hp.owl",
+            "description": "A phenotype ontology term from the Human Phenotype (HP) Ontology. PURL: http://purl.obolibrary.org/obo/hp.owl",
             "properties": {
                 "ancestors": {
                     "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -293,6 +293,10 @@
                     "description": "The model organism database (MOD) identifier/curie for the object",
                     "type": "string"
                 },
+                "mod_internal_id": {
+                    "description": "The model organism database (MOD) internal identifier for the object",
+                    "type": "string"
+                },
                 "negated": {
                     "description": "if set to true, then the association is negated i.e. is not true",
                     "type": "boolean"
@@ -2319,6 +2323,10 @@
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
+                    "type": "string"
+                },
+                "mod_internal_id": {
+                    "description": "The model organism database (MOD) internal identifier for the object",
                     "type": "string"
                 },
                 "negated": {
@@ -10318,6 +10326,10 @@
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
+                    "type": "string"
+                },
+                "mod_internal_id": {
+                    "description": "The model organism database (MOD) internal identifier for the object",
                     "type": "string"
                 },
                 "negated": {

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -57,13 +57,16 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "disease_genetic_modifier": {
-                    "description": "Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.",
-                    "type": "string"
-                },
                 "disease_genetic_modifier_relation": {
                     "description": "A relation describing how the genetic modifier modifies the disease model. Submitted value should be a vocabulary term from the 'Disease genetic modifiers' vocabulary",
                     "type": "string"
+                },
+                "disease_genetic_modifiers": {
+                    "description": "Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "disease_qualifiers": {
                     "description": "Submitted values should be vocabulary terms from the 'Disease qualifiers' Vocabulary",
@@ -104,6 +107,10 @@
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the disease annotation. Currently only used by WormBase for disease annotations, e.g. \"WBDOannot00000907\"",
+                    "type": "string"
+                },
+                "mod_internal_id": {
+                    "description": "The model organism database (MOD) internal identifier for the disease annotation. When available, this is used for determination of distinctness instead of the Unique ID field.",
                     "type": "string"
                 },
                 "negated": {
@@ -435,6 +442,123 @@
             "title": "AGMPhenotypeAnnotation",
             "type": "object"
         },
+        "APOTerm": {
+            "additionalProperties": false,
+            "description": "A phenotype ontology term from the Ascomycete Phenotype Ontology (APO). PURL: http://purl.obolibrary.org/obo/APO.owl",
+            "properties": {
+                "ancestors": {
+                    "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": "array"
+                },
+                "curie": {
+                    "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "dbkey": {
+                    "description": "Typically the primary key on the table.  Should be a global sequence in the database to insure uniqueness over the entire suite of tables.  Alternatively, could be a serial8 identifier. Tables with a dbkey should have an alternate key to establish uniqueness based on the data in the table.",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "The definition of the ontology term. This is a reference to an object that holds the text description of the term and a collection of URLs that further define the term.",
+                    "type": "string"
+                },
+                "definition_urls": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "descendants": {
+                    "description": "The descendants of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms to which this term develops into (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "a human-readable name for an entity",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "the namespace of the ontology.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "subsets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "synonyms": {
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "curie",
+                "internal"
+            ],
+            "title": "APOTerm",
+            "type": "object"
+        },
         "ATPTerm": {
             "additionalProperties": false,
             "description": "An ontology term from the Alliance Tags for Papers ontology (ATP)",
@@ -531,7 +655,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -1970,13 +2094,16 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "disease_genetic_modifier": {
-                    "description": "Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.",
-                    "type": "string"
-                },
                 "disease_genetic_modifier_relation": {
                     "description": "A relation describing how the genetic modifier modifies the disease model. Submitted value should be a vocabulary term from the 'Disease genetic modifiers' vocabulary",
                     "type": "string"
+                },
+                "disease_genetic_modifiers": {
+                    "description": "Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "disease_qualifiers": {
                     "description": "Submitted values should be vocabulary terms from the 'Disease qualifiers' Vocabulary",
@@ -2013,6 +2140,10 @@
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the disease annotation. Currently only used by WormBase for disease annotations, e.g. \"WBDOannot00000907\"",
+                    "type": "string"
+                },
+                "mod_internal_id": {
+                    "description": "The model organism database (MOD) internal identifier for the disease annotation. When available, this is used for determination of distinctness instead of the Unique ID field.",
                     "type": "string"
                 },
                 "negated": {
@@ -6016,7 +6147,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -6133,7 +6264,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -7337,7 +7468,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -7530,7 +7661,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -7549,6 +7680,123 @@
                 "internal"
             ],
             "title": "DOTerm",
+            "type": "object"
+        },
+        "DPOTerm": {
+            "additionalProperties": false,
+            "description": "A phenotype ontology term from the Drosophila Phenotype Ontology (DPO). PURL: http://purl.obolibrary.org/obo/dpo.owl",
+            "properties": {
+                "ancestors": {
+                    "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": "array"
+                },
+                "curie": {
+                    "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "dbkey": {
+                    "description": "Typically the primary key on the table.  Should be a global sequence in the database to insure uniqueness over the entire suite of tables.  Alternatively, could be a serial8 identifier. Tables with a dbkey should have an alternate key to establish uniqueness based on the data in the table.",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "The definition of the ontology term. This is a reference to an object that holds the text description of the term and a collection of URLs that further define the term.",
+                    "type": "string"
+                },
+                "definition_urls": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "descendants": {
+                    "description": "The descendants of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms to which this term develops into (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "a human-readable name for an entity",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "the namespace of the ontology.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "subsets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "synonyms": {
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "curie",
+                "internal"
+            ],
+            "title": "DPOTerm",
             "type": "object"
         },
         "DataProvider": {
@@ -7957,7 +8205,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -8074,7 +8322,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -8727,7 +8975,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -8844,7 +9092,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -9233,7 +9481,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -9854,13 +10102,16 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "disease_genetic_modifier": {
-                    "description": "Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.",
-                    "type": "string"
-                },
                 "disease_genetic_modifier_relation": {
                     "description": "A relation describing how the genetic modifier modifies the disease model. Submitted value should be a vocabulary term from the 'Disease genetic modifiers' vocabulary",
                     "type": "string"
+                },
+                "disease_genetic_modifiers": {
+                    "description": "Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "disease_qualifiers": {
                     "description": "Submitted values should be vocabulary terms from the 'Disease qualifiers' Vocabulary",
@@ -9893,6 +10144,10 @@
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the disease annotation. Currently only used by WormBase for disease annotations, e.g. \"WBDOannot00000907\"",
+                    "type": "string"
+                },
+                "mod_internal_id": {
+                    "description": "The model organism database (MOD) internal identifier for the disease annotation. When available, this is used for determination of distinctness instead of the Unique ID field.",
                     "type": "string"
                 },
                 "negated": {
@@ -10489,7 +10744,7 @@
                     "description": "Holds between an object and a Note object."
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -11691,6 +11946,123 @@
             "title": "GenomicLocationAssociationDTO",
             "type": "object"
         },
+        "HPTerm": {
+            "additionalProperties": false,
+            "description": "A phenotype ontology term from the Human Phenotype (MP) Ontology. PURL: http://purl.obolibrary.org/obo/hp.owl",
+            "properties": {
+                "ancestors": {
+                    "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": "array"
+                },
+                "curie": {
+                    "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "dbkey": {
+                    "description": "Typically the primary key on the table.  Should be a global sequence in the database to insure uniqueness over the entire suite of tables.  Alternatively, could be a serial8 identifier. Tables with a dbkey should have an alternate key to establish uniqueness based on the data in the table.",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "The definition of the ontology term. This is a reference to an object that holds the text description of the term and a collection of URLs that further define the term.",
+                    "type": "string"
+                },
+                "definition_urls": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "descendants": {
+                    "description": "The descendants of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms to which this term develops into (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "a human-readable name for an entity",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "the namespace of the ontology.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "subsets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "synonyms": {
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "curie",
+                "internal"
+            ],
+            "title": "HPTerm",
+            "type": "object"
+        },
         "HeavyChainIsotypeSet": {
             "description": "",
             "enum": [
@@ -12593,7 +12965,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -12710,7 +13082,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -12827,7 +13199,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -12944,7 +13316,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -12967,7 +13339,7 @@
         },
         "MPTerm": {
             "additionalProperties": false,
-            "description": "",
+            "description": "A phenotype ontology term from the Mammalian Phenotype (MP) Ontology. PURL: http://purl.obolibrary.org/obo/mp.owl",
             "properties": {
                 "ancestors": {
                     "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
@@ -13061,7 +13433,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -13352,7 +13724,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -13469,7 +13841,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -13704,6 +14076,123 @@
             "title": "NoteDTO",
             "type": "object"
         },
+        "OBITerm": {
+            "additionalProperties": false,
+            "description": "An ontology term from the Ontology for Biomedical Investigations (OBI). PURL: http://purl.obolibrary.org/obo/obi.owl",
+            "properties": {
+                "ancestors": {
+                    "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": "array"
+                },
+                "curie": {
+                    "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "dbkey": {
+                    "description": "Typically the primary key on the table.  Should be a global sequence in the database to insure uniqueness over the entire suite of tables.  Alternatively, could be a serial8 identifier. Tables with a dbkey should have an alternate key to establish uniqueness based on the data in the table.",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "The definition of the ontology term. This is a reference to an object that holds the text description of the term and a collection of URLs that further define the term.",
+                    "type": "string"
+                },
+                "definition_urls": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "descendants": {
+                    "description": "The descendants of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms to which this term develops into (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "a human-readable name for an entity",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "the namespace of the ontology.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "subsets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "synonyms": {
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "curie",
+                "internal"
+            ],
+            "title": "OBITerm",
+            "type": "object"
+        },
         "OntologyBulkLoadTypeEnum": {
             "description": "",
             "enum": [
@@ -13820,7 +14309,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -14054,6 +14543,123 @@
                 "internal"
             ],
             "title": "Organization",
+            "type": "object"
+        },
+        "PATOTerm": {
+            "additionalProperties": false,
+            "description": "An ontology term from the Phenotype and Trait Ontology (PATO). PURL: http://purl.obolibrary.org/obo/PATO.owl",
+            "properties": {
+                "ancestors": {
+                    "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": "array"
+                },
+                "curie": {
+                    "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "dbkey": {
+                    "description": "Typically the primary key on the table.  Should be a global sequence in the database to insure uniqueness over the entire suite of tables.  Alternatively, could be a serial8 identifier. Tables with a dbkey should have an alternate key to establish uniqueness based on the data in the table.",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "The definition of the ontology term. This is a reference to an object that holds the text description of the term and a collection of URLs that further define the term.",
+                    "type": "string"
+                },
+                "definition_urls": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "descendants": {
+                    "description": "The descendants of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms to which this term develops into (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "a human-readable name for an entity",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "the namespace of the ontology.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "subsets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "synonyms": {
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "curie",
+                "internal"
+            ],
+            "title": "PATOTerm",
             "type": "object"
         },
         "Pathway": {
@@ -14445,7 +15051,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -14893,7 +15499,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -15244,7 +15850,7 @@
                     "type": "string"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -15334,7 +15940,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -15508,7 +16114,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -16411,7 +17017,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -17298,6 +17904,13 @@
                     "description": "Entity is no longer current.",
                     "type": "boolean"
                 },
+                "synonyms": {
+                    "description": "Free text synonym(s) of a controlled vocabulary term",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": "string"
@@ -17544,7 +18157,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -17661,7 +18274,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -17680,6 +18293,123 @@
                 "internal"
             ],
             "title": "WBLSTerm",
+            "type": "object"
+        },
+        "WBPhenotypeTerm": {
+            "additionalProperties": false,
+            "description": "A phenotype ontology term from the (WormBase) C. elegans Phenotype Ontology (WBPhenotype). PURL: http://purl.obolibrary.org/obo/wbphenotype.owl",
+            "properties": {
+                "ancestors": {
+                    "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": "array"
+                },
+                "curie": {
+                    "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "dbkey": {
+                    "description": "Typically the primary key on the table.  Should be a global sequence in the database to insure uniqueness over the entire suite of tables.  Alternatively, could be a serial8 identifier. Tables with a dbkey should have an alternate key to establish uniqueness based on the data in the table.",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "The definition of the ontology term. This is a reference to an object that holds the text description of the term and a collection of URLs that further define the term.",
+                    "type": "string"
+                },
+                "definition_urls": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "descendants": {
+                    "description": "The descendants of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms to which this term develops into (not a true parent/child or ancestor/descendant relationship).",
+                    "items": {
+                        "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": "array"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "a human-readable name for an entity",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "the namespace of the ontology.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "subsets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "synonyms": {
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "curie",
+                "internal"
+            ],
+            "title": "WBPhenotypeTerm",
             "type": "object"
         },
         "XBATerm": {
@@ -17778,7 +18508,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -17895,7 +18625,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -18012,7 +18742,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -18129,7 +18859,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -18152,7 +18882,7 @@
         },
         "XPOTerm": {
             "additionalProperties": false,
-            "description": "",
+            "description": "A phenotype ontology term from the Xenopus Phenotype Ontology (XPO). PURL: http://purl.obolibrary.org/obo/xpo.owl",
             "properties": {
                 "ancestors": {
                     "description": "The ancestors of this term in the ontology, including the term itself. This language works well for the majority of use cases, however for a relationship like \"develops_from\", ancestors are the terms from which this term develops (not a true parent/child or ancestor/descendant relationship).",
@@ -18246,7 +18976,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -18383,7 +19113,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -18500,7 +19230,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -18617,7 +19347,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -18734,7 +19464,7 @@
                     "type": "array"
                 },
                 "synonyms": {
-                    "description": "Placeholder? Some objects still use this slot. Not clear how it fits in with NameSlotAnnotation (which captures evidence).",
+                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -17925,13 +17925,6 @@
                     "description": "Entity is no longer current.",
                     "type": "boolean"
                 },
-                "synonyms": {
-                    "description": "Free text synonym(s) of a controlled vocabulary term",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": "string"
@@ -17995,8 +17988,8 @@
                     "description": "Entity is no longer current.",
                     "type": "boolean"
                 },
-                "text_synonyms": {
-                    "description": "Free text synonym(s) of a term, used for controlled vocabulary terms; this is distinct from the 'synonyms' slot which has a range of a Synonym class object.",
+                "synonyms": {
+                    "description": "Free text synonym(s) of a controlled vocabulary term",
                     "items": {
                         "type": "string"
                     },

--- a/model/schema/controlledVocabulary.yaml
+++ b/model/schema/controlledVocabulary.yaml
@@ -91,10 +91,15 @@ classes:
       - name
       - vocabulary_description
       - member_terms
+      - synonyms
     slot_usage:
       name:
         required: true
         identifier: true
+      synonyms:
+        description: >-
+          Free text synonym(s) of a controlled vocabulary term
+        required: false
 
   VocabularyTermSet:
     is_a: AuditedObject

--- a/model/schema/controlledVocabulary.yaml
+++ b/model/schema/controlledVocabulary.yaml
@@ -34,13 +34,6 @@ prefixes:
   schema: 'http://schema.org/'
 
 slots:
-  text_synonyms:
-    description: >-
-      Free text synonym(s) of a term, used for controlled vocabulary terms; this is distinct from the
-      'synonyms' slot which has a range of a Synonym class object.
-    domain: VocabularyTerm
-    range: string
-    multivalued: true
 
   member_terms:
     description: >-
@@ -77,20 +70,6 @@ classes:
       - name
       - abbreviation
       - definition
-      - text_synonyms
-    slot_usage:
-      name:
-        required: true
-        identifier: true
-
-  Vocabulary:
-    description: >-
-      A set of VocabularyTerm objects.
-    is_a: AuditedObject
-    slots:
-      - name
-      - vocabulary_description
-      - member_terms
       - synonyms
     slot_usage:
       name:
@@ -100,6 +79,20 @@ classes:
         description: >-
           Free text synonym(s) of a controlled vocabulary term
         required: false
+
+  Vocabulary:
+    description: >-
+      A set of VocabularyTerm objects.
+    is_a: AuditedObject
+    slots:
+      - name
+      - vocabulary_description
+      - member_terms
+    slot_usage:
+      name:
+        required: true
+        identifier: true
+
 
   VocabularyTermSet:
     is_a: AuditedObject

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -804,8 +804,9 @@ slots:
 
   synonyms:
     description: >-
-      Placeholder? Some objects still use this slot. Not clear how it fits in
-      with NameSlotAnnotation (which captures evidence).
+      A generic free-text field for objects that only have string representation of one
+      or more synonyms and do not require meta data or attribution; if meta data or attribution
+      are required to be captured for individual synonyms, consider the NameSlotAnnotation class
     range: string
     required: false
     multivalued: true
@@ -856,6 +857,11 @@ slots:
     description: >-
       The model organism database (MOD) identifier/curie for the object
     range: string
+
+  mod_internal_id:
+    description: >-
+      The model organism database (MOD) internal identifier for the object
+      range: string
 
   first_name:
     description: first name of a person

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -861,7 +861,7 @@ slots:
   mod_internal_id:
     description: >-
       The model organism database (MOD) internal identifier for the object
-      range: string
+    range: string
 
   first_name:
     description: first name of a person

--- a/model/schema/ontologyTerm.yaml
+++ b/model/schema/ontologyTerm.yaml
@@ -298,7 +298,7 @@ classes:
   HPTerm:
     is_a: PhenotypeTerm
     description: >-
-      A phenotype ontology term from the Human Phenotype (MP) Ontology.
+      A phenotype ontology term from the Human Phenotype (HP) Ontology.
       PURL: http://purl.obolibrary.org/obo/hp.owl
 
   WBPhenotypeTerm:

--- a/model/schema/ontologyTerm.yaml
+++ b/model/schema/ontologyTerm.yaml
@@ -216,7 +216,6 @@ classes:
     is_a: OntologyTerm
     abstract: true
 
-
   FBDVTerm:
     is_a: StageTerm
 
@@ -286,9 +285,51 @@ classes:
 
   XPOTerm:
     is_a: PhenotypeTerm
+    description: >-
+      A phenotype ontology term from the Xenopus Phenotype Ontology (XPO).
+      PURL: http://purl.obolibrary.org/obo/xpo.owl
 
   MPTerm:
     is_a: PhenotypeTerm
+    description: >-
+      A phenotype ontology term from the Mammalian Phenotype (MP) Ontology.
+      PURL: http://purl.obolibrary.org/obo/mp.owl
+
+  HPTerm:
+    is_a: PhenotypeTerm
+    description: >-
+      A phenotype ontology term from the Human Phenotype (MP) Ontology.
+      PURL: http://purl.obolibrary.org/obo/hp.owl
+
+  WBPhenotypeTerm:
+    is_a: PhenotypeTerm
+    description: >-
+      A phenotype ontology term from the (WormBase) C. elegans Phenotype Ontology (WBPhenotype).
+      PURL: http://purl.obolibrary.org/obo/wbphenotype.owl
+
+  APOTerm:
+    is_a: PhenotypeTerm
+    description: >-
+      A phenotype ontology term from the Ascomycete Phenotype Ontology (APO).
+      PURL: http://purl.obolibrary.org/obo/APO.owl
+
+  DPOTerm:
+    is_a: PhenotypeTerm
+    description: >-
+      A phenotype ontology term from the Drosophila Phenotype Ontology (DPO).
+      PURL: http://purl.obolibrary.org/obo/dpo.owl
+
+  PATOTerm:
+    is_a: OntologyTerm
+    description: >-
+      An ontology term from the Phenotype and Trait Ontology (PATO).
+      PURL: http://purl.obolibrary.org/obo/PATO.owl
+
+  OBITerm:
+    is_a: OntologyTerm
+    description: >-
+      An ontology term from the Ontology for Biomedical Investigations (OBI).
+      PURL: http://purl.obolibrary.org/obo/obi.owl
 
   ATPTerm:
     is_a: OntologyTerm

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -183,6 +183,7 @@ classes:
       - curie
       - unique_id
       - mod_entity_id
+      - mod_internal_id
       - negated
       - evidence_codes
       - single_reference
@@ -194,7 +195,7 @@ classes:
       - related_notes
       - data_provider
       - secondary_data_provider
-      - disease_genetic_modifier
+      - disease_genetic_modifiers
       - disease_genetic_modifier_relation
     slot_usage:
       curie:
@@ -211,6 +212,12 @@ classes:
         description: >-
           The model organism database (MOD) identifier/curie for the disease annotation. Currently only
           used by WormBase for disease annotations, e.g. "WBDOannot00000907"
+        required: false
+      mod_internal_id:
+        description: >-
+          The model organism database (MOD) internal identifier for the disease annotation. When available,
+          this is used for determination of distinctness instead of the Unique ID field.
+        required: false
       subject:
         required: true
         description: >-
@@ -681,10 +688,11 @@ slots:
     inlined: true
     inlined_as_list: true
 
-  disease_genetic_modifier:
+  disease_genetic_modifiers:
     description: >-
       Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.
     required: false
+    multivalued: true
 
   disease_genetic_modifier_curie:
     description: Curie of BiologcalEntity that modifies the disease model

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -275,6 +275,7 @@ classes:
       - disease_relation_name
       - do_term_curie
       - mod_entity_id
+      - mod_internal_id
       - negated
       - evidence_curies
       - evidence_code_curies

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -287,7 +287,7 @@ classes:
       - note_dtos
       - data_provider_dto
       - secondary_data_provider_dto
-      - disease_genetic_modifier_curie
+      - disease_genetic_modifier_curies
       - disease_genetic_modifier_relation_name
 
   GeneDiseaseAnnotation:
@@ -694,10 +694,11 @@ slots:
     required: false
     multivalued: true
 
-  disease_genetic_modifier_curie:
+  disease_genetic_modifier_curies:
     description: Curie of BiologcalEntity that modifies the disease model
     domain: DiseaseAnnotationDTO
     range: string
+    multivalued: true
 
   disease_genetic_modifier_relation:
     description: >-

--- a/test/data/wb_disease_test.json
+++ b/test/data/wb_disease_test.json
@@ -46,6 +46,7 @@
       ],
       "genetic_sex_name": "hermaphrodite",
       "mod_entity_id": "WBDOannot00001032",
+      "mod_internal_id": "MGI:diseaseannotation_239930183_295748146",
       "updated_by_curie": "WB:WBPerson324",
       "internal": false,
       "negated": false,

--- a/test/data/wb_disease_test.json
+++ b/test/data/wb_disease_test.json
@@ -90,7 +90,7 @@
           "internal": false
         }
       ],
-      "disease_genetic_modifier_curie": "WB:WBStrain00035193",
+      "disease_genetic_modifier_curies": ["WB:WBStrain00035193"],
       "disease_genetic_modifier_relation_name": "ameliorated_by",
       "evidence_code_curies": [
         "ECO:0000315",
@@ -122,7 +122,7 @@
         "internal": false
       },
       "date_updated": "2019-03-08T00:00:00+00:00",
-      "disease_genetic_modifier_curie": "WB:WBVar00250993",
+      "disease_genetic_modifier_curies": ["WB:WBVar00250993"],
       "disease_genetic_modifier_relation_name": "exacerbated_by",
       "evidence_code_curies": [
         "ECO:0000315",


### PR DESCRIPTION
- Added several new ontology term classes
- Added 'mod_internal_id' slot definition; slot added to DiseaseAnnotation class
- Added 'synonyms' slot to VocabularyTerm class; updated description of 'synonyms' slot in core.yaml
- Changed 'disease_genetic_modifier' slot to 'disease_genetic_modifiers' and made multivalued 