### PR TITLE
Secondary IDs update

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -16158,6 +16158,64 @@
             "title": "SOTerm",
             "type": "object"
         },
+        "SecondaryIdSlotAnnotation": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "evidence": {
+                    "description": "",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "secondary_id": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "secondary_id",
+                "internal"
+            ],
+            "title": "SecondaryIdSlotAnnotation",
+            "type": "object"
+        },
         "SecondaryIdSlotAnnotationDTO": {
             "additionalProperties": false,
             "description": "",

--- a/model/schema/affectedGenomicModel.yaml
+++ b/model/schema/affectedGenomicModel.yaml
@@ -66,7 +66,7 @@ classes:
       - single_agm
       - secondary_id
     slot_usage:
-      single_allele:
+      single_agm:
         required: true
       secondary_id:
         required: true
@@ -120,7 +120,7 @@ slots:
     required: true
 
   agm_secondary_ids:
-    description: Secondary IDs of a given allele
+    description: Secondary IDs of a given AGM
     domain: AffectedGenomicModel
     range: AgmSecondaryIdSlotAnnotation
     multivalued: true

--- a/model/schema/affectedGenomicModel.yaml
+++ b/model/schema/affectedGenomicModel.yaml
@@ -43,6 +43,7 @@ classes:
     slots:
       - name
       - subtype
+      - agm_secondary_ids
       - components
       - sequence_targeting_reagents
       - parental_populations
@@ -54,9 +55,21 @@ classes:
     slots:
       - name
       - subtype_name
+      - agm_secondary_id_dtos
       - reference_curies
       - sequence_targeting_reagent_curies
       - component_dtos
+
+  AgmSecondaryIdSlotAnnotation:
+    is_a: SlotAnnotation
+    slots:
+      - single_agm
+      - secondary_id
+    slot_usage:
+      single_allele:
+        required: true
+      secondary_id:
+        required: true
 
   AffectedGenomicModelComponent:
     is_a: AuditedObject
@@ -86,6 +99,10 @@ slots:
     range: string
     required: true
 
+  single_agm:
+    range: AffectedGenomicModel
+    multivalued: false
+
   subtype:
     description: >-
       Subtype of affected genomic model - permissible values: strain / genotype
@@ -101,6 +118,19 @@ slots:
     domain: AffectedGenomicModelDTO
     range: string
     required: true
+
+  agm_secondary_ids:
+    description: Secondary IDs of a given allele
+    domain: AffectedGenomicModel
+    range: AgmSecondaryIdSlotAnnotation
+    multivalued: true
+
+  agm_secondary_id_dtos:
+    domain: AffectedGenomicModelDTO
+    range: SecondaryIdSlotAnnotationDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
 
   components:
     singular_name: component

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -289,14 +289,11 @@ classes:
         required: true
 
   AlleleSecondaryIdSlotAnnotation:
-    is_a: SlotAnnotation
+    is_a: SecondaryIdSlotAnnotation
     slots:
       - single_allele
-      - secondary_id
     slot_usage:
       single_allele:
-        required: true
-      secondary_id:
         required: true
 
   AlleleSymbolSlotAnnotation:

--- a/model/schema/alleleDTO.yaml
+++ b/model/schema/alleleDTO.yaml
@@ -170,14 +170,6 @@ classes:
       note_dto:
         required: true
 
-  AlleleSecondaryIdSlotAnnotationDTO:
-    is_a: SlotAnnotationDTO
-    slots:
-      - secondary_id
-    slot_usage:
-      secondary_id:
-        required: true
-
 
 ## ------------
 ## ALLELE DTO ASSOCIATION CLASSES
@@ -376,7 +368,7 @@ slots:
 
   allele_secondary_id_dtos:
     domain: AlleleDTO
-    range: AlleleSecondaryIdSlotAnnotationDTO
+    range: SecondaryIdSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -275,7 +275,7 @@ classes:
         any_of:
           - equals_string: systematic_name
 
- SecondaryIdSlotAnnotation:
+  SecondaryIdSlotAnnotation:
     is_a: SlotAnnotation
     slots:
       - secondary_id

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -275,6 +275,14 @@ classes:
         any_of:
           - equals_string: systematic_name
 
+ SecondaryIdSlotAnnotation:
+    is_a: SlotAnnotation
+    slots:
+      - secondary_id
+    slot_usage:
+      secondary_id:
+        required: true
+        
   SecondaryIdSlotAnnotationDTO:
     is_a: SlotAnnotationDTO
     slots:

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -120,14 +120,12 @@ classes:
       RNA transcript translation).
     slots:
       - cross_references
-      - secondary_identifiers
       - genomic_location_associations
 
   GenomicEntityDTO:
     is_a: BiologicalEntityDTO
     slots:
       - cross_reference_dtos
-      - secondary_identifiers
       - genomic_location_association_dtos
 
   Transcript:
@@ -276,6 +274,14 @@ classes:
       name_type_name:
         any_of:
           - equals_string: systematic_name
+
+  SecondaryIdSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
+    slots:
+      - secondary_id
+    slot_usage:
+      secondary_id:
+        required: true
 
 
   Association:

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -54,6 +54,7 @@ classes:
       - gene_full_name
       - gene_systematic_name
       - gene_synonyms
+      - gene_secondary_ids
       - related_notes
       - gene_type
       - gene_types_secondary
@@ -91,6 +92,7 @@ classes:
       - gene_full_name_dto
       - gene_systematic_name_dto
       - gene_synonym_dtos
+      - gene_secondary_id_dtos
       - gene_type_curie
 
   GeneSymbolSlotAnnotation:
@@ -119,6 +121,17 @@ classes:
         notes: >-
           permissible_values: full_name (VocabularyTerm)
 
+  GeneSecondaryIdSlotAnnotation:
+    is_a: SlotAnnotation
+    slots:
+      - single_gene
+      - secondary_id
+    slot_usage:
+      single_gene:
+        required: true
+      secondary_id:
+        required: true
+        
   GeneSystematicNameSlotAnnotation:
     is_a: NameSlotAnnotation
     description: >-
@@ -238,6 +251,19 @@ slots:
     multivalued: false
     required: false
     inlined: true
+
+  gene_secondary_ids:
+    description: Secondary IDs of a given gene
+    domain: Gene
+    range: GeneSecondaryIdSlotAnnotation
+    multivalued: true
+
+  gene_secondary_id_dtos:
+    domain: GeneDTO
+    range: SecondaryIdSlotAnnotationDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
 
   gene_systematic_name:
     description: >-

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -122,14 +122,11 @@ classes:
           permissible_values: full_name (VocabularyTerm)
 
   GeneSecondaryIdSlotAnnotation:
-    is_a: SlotAnnotation
+    is_a: SecondaryIdSlotAnnotation
     slots:
       - single_gene
-      - secondary_id
     slot_usage:
       single_gene:
-        required: true
-      secondary_id:
         required: true
         
   GeneSystematicNameSlotAnnotation:

--- a/test/data/agm_test.json
+++ b/test/data/agm_test.json
@@ -8,8 +8,14 @@
       "updated_by_curie": "ZFIN",
       "internal": false,
       "name": "TL + MO1-hars",
-      "secondary_identifiers": [
-        "ZFIN:ZDB-FISH-123456-1"
+      "agm_secondary_id_dtos": [
+        {
+          "secondary_id": "ZFIN:ZDB-FISH-123456-1",
+          "evidence_curies": [
+            "PMID:00020012"
+          ],
+          "internal": false
+        }
       ],
       "reference_curies": [],
       "sequence_targeting_reagent_curies": [
@@ -35,8 +41,14 @@
       "updated_by_curie": "ZFIN",
       "internal": false,
       "name": "pax2a<sup>tb21/tb21</sup>",
-      "secondary_identifiers": [
-        "ZFIN:ZDB-FISH-123456-1"
+      "agm_secondary_id_dtos": [
+        {
+          "secondary_id": "ZFIN:ZDB-FISH-123456-1",
+          "evidence_curies": [
+            "PMID:00020012"
+          ],
+          "internal": false
+        }
       ],
       "reference_curies": [],
       "component_dtos": [

--- a/test/data/allele_test.json
+++ b/test/data/allele_test.json
@@ -39,7 +39,16 @@
           "PMID:01231002"
         ],
         "internal": false
-      }
+      },
+      "allele_secondary_id_dtos": [
+        {
+          "secondary_id": "scnd_id",
+          "evidence_curies": [
+            "PMID:00020012"
+          ],
+          "internal": false
+        }
+      ]
     },
     {
       "curie": "ZFIN:ZDB-ALT-130411-947",

--- a/test/data/gene_test.json
+++ b/test/data/gene_test.json
@@ -64,6 +64,15 @@
           "internal": false
         }
       ],
+      "gene_secondary_id_dtos": [
+        {
+          "secondary_id": "scnd_id",
+          "evidence_curies": [
+            "PMID:00020012"
+          ],
+          "internal": false
+        }
+      ],
       "cross_reference_dtos": [
         {
           "referenced_curie": "ZFIN:ZDB-GENE-010226-1",

--- a/test/data/sqtr_test.json
+++ b/test/data/sqtr_test.json
@@ -7,9 +7,6 @@
       "created_by_curie": "ZFIN",
       "updated_by_curie": "ZFIN",
       "internal": false,
-      "secondary_identifiers": [
-        "ZFIN:ZDB-MRPHLNO-123456-1"
-      ],
       "reference_curies": [
         "PMID:19648295"
       ],
@@ -42,9 +39,6 @@
       "created_by_curie": "ZFIN",
       "updated_by_curie": "ZFIN",
       "internal": false,
-      "secondary_identifiers": [
-        "ZFIN:ZDB-MRPHLNO-123456-1"
-      ],
       "reference_curies": [
         "PMID:19648295"
       ]
@@ -66,9 +60,6 @@
       "created_by_curie": "ZFIN",
       "updated_by_curie": "ZFIN",
       "internal": false,
-      "secondary_identifiers": [
-        "ZFIN:ZDB-MRPHLNO-123456-1"
-      ],
       "reference_curies": [
         "PMID:19648295"
       ]


### PR DESCRIPTION
In the current model the `GenomicEntity` class has a `secondary_identifiers` slot, which is multivalued and has a range of `string.`  However, the `Allele` class inherits that slot but also has `allele_secondary_ids` with a range of `AlleleSecondaryIdSlotAnnotation`.  We don't want `Allele` to have both slots, and presumably we want to use the SlotAnnotation paradigm for secondary IDs elsewhere.

In this PR I have removed `secondary_identifiers` from `GenomicEntity` and implemented the SlotAnnotation paradigm for genes and AGMs - we may wish to also do so for other classes that inherit from GenomicEntity or we may wish to stick with the simpler list of strings for those, or not even have secondary IDs at all for some classes.