### PR TITLE
Relax curie and taxon requirements for Reagent class

### DIFF
--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -48,11 +48,7 @@ classes:
       - taxon
       - generated_by
       - manufactured_by
-    slot_usage:
-      curie:
-        required: true
-      taxon:
-        required: false
+
 
   Antibody:
     is_a: Reagent


### PR DESCRIPTION
@draciti @gildossantos 
I think you (or someone in the Expression working group) had created the original Reagent class definition, including a requirement on taxon and curie. This pull request is to remove the requirement for taxon and curie, since we have Construct as a subclass of Reagent and, at least for WormBase, we cannot require specification of a single taxon (or any taxon in some cases). Also, it is unclear to me if we know, at this point, that all Reagent records will necessarily have a curie. If I can confirm that all Reagents (including instances of Construct, Antibody, DNAClone, and RNAClone) will have a curie coming from the MOD, then we can keep that constraint. 

Let me know what you think.