### PR TITLE
SCRUM-3230 Construct ingest classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ deploy-testpypi:
 
 # datasets used test/validate the schema
 SCHEMA_TEST_EXAMPLES := \
+	construct_test \
 	allele_test \
 	disease_allele_test \
 	disease_agm_test \

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -7278,7 +7278,6 @@
             "required": [
                 "name",
                 "curie",
-                "taxon_curie",
                 "internal"
             ],
             "title": "ConstructDTO",
@@ -16846,7 +16845,6 @@
             },
             "required": [
                 "curie",
-                "taxon_curie",
                 "internal"
             ],
             "title": "ReagentDTO",

--- a/model/schema/affectedGenomicModel.yaml
+++ b/model/schema/affectedGenomicModel.yaml
@@ -47,6 +47,11 @@ classes:
       - sequence_targeting_reagents
       - parental_populations
       - references
+    slot_usage:
+      name:
+        notes: >-
+          May want to convert this into a slot that uses NameSlotAnnotation.
+    
 
   AffectedGenomicModelDTO:
     is_a: GenomicEntityDTO
@@ -85,14 +90,6 @@ classes:
       - zygosity_curie
 
 slots:
-
-  name:
-    description: >-
-      a human-readable name for an entity
-    notes: >-
-      May want to convert this into a slot that uses NameSlotAnnotation.
-    multivalued: false
-    range: string
 
   agm_curie:
     range: string

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -137,95 +137,6 @@ classes:
     description: >-
       Dummy cell line DTO class
 
-  Construct:
-    is_a: Reagent
-    slots:
-      - construct_genomic_entity_associations
-      - construct_components
-      - name
-      - references
-    slot_usage:
-      curie:
-        identifier: true
-      name:
-        required: true
-
-  ConstructDTO:
-    is_a: ReagentDTO
-    slots:
-      - name
-      - construct_component_dtos
-      - reference_curies
-    slot_usage:
-      name:
-        required: true
-
-  ConstructComponentSlotAnnotation:
-    is_a: SlotAnnotation
-    slots:
-      - single_construct
-      - component_symbol
-      - related_notes
-      - taxon
-      - taxon_text
-    slot_usage:
-      single_construct:
-        required: true
-      component_symbol:
-        required: true
-      related_notes:
-        required: false
-      taxon:
-        required: false
-      taxon_text:
-        required: false
-
-  ConstructComponentSlotAnnotationDTO:
-    is_a: SlotAnnotationDTO
-    slots:
-      - component_symbol
-      - note_dtos
-      - taxon_curie
-      - taxon_text
-
-  ConstructGenomicEntityAssociation:
-    is_a: Association
-    description: >-
-      An association class to capture the identity of a construct component that is
-      a known genomic entity with a curie and any accompanying meta data about the
-      relationship between the construct and that genomic entity component
-    slots:
-      - related_notes
-    slot_usage:
-      subject:
-        range: Construct
-      predicate:
-        range: VocabularyTerm
-        notes: >-
-          The predicate should be a VocabularyTerm with one of the following
-          values - expresses (RO:0002292) / is_regulated_by (RO:0002334) /
-          targets (RO:0002436). CV: 'Construct Genomic Entity Association Predicate'
-      object:
-        range: GenomicEntity
-      related_notes:
-        required: false
-
-  ConstructGenomicEntityAssociationDTO:
-    is_a: AuditedObjectDTO
-    description: >-
-      Ingest class for association between a construct component that is a known genomic
-      entity with a curie and any accompanying meta data about the relationship between
-      the construct and that genomic entity component
-    slots:
-      - construct_curie
-      - genomic_entity_relation_name
-      - genomic_entity_curie
-      - note_dtos
-      - evidence_curies
-    slot_usage:
-      genomic_entity_curie:
-        required: true
-
   GenerationMethod:
     is_a: AuditedObject
     slots:
@@ -945,33 +856,6 @@ slots:
     domain: GenerationMethodDTO
     range: string # CV 'Chemical Mutagens'
 
-  component_symbol:
-    range: string
-    required: true
-    description: >-
-      The free text of a symbol or name of a construct
-      component for which no curie exists or is available
-
-  construct_components:
-    multivalued: true
-    domain: Construct
-    range: ConstructComponentSlotAnnotation
-
-  construct_component_dtos:
-    multivalued: true
-    range: ConstructComponentSlotAnnotationDTO
-    inlined: true
-    inlined_as_list: true
-
-  construct_curie:
-    range: string
-    required: true
-
-  construct_genomic_entity_associations:
-    multivalued: true
-    domain: Construct
-    range: ConstructGenomicEntityAssociation
-
   database_status:
     description: >-
       Database status of the allele
@@ -1009,14 +893,6 @@ slots:
     range: GenerationMethodDTO
     multivalued: false
     inlined: true
-
-  genomic_entity_relation_name:
-    description: >-
-      Name of the VocabularyTerm describing the relationship between
-      Construct and GenomicEntity
-    domain: ConstructGenomicEntityAssociationDTO
-    range: string
-    required: true
 
   germline_transmission_status:
     description: >-
@@ -1201,16 +1077,6 @@ slots:
   single_allele:
     range: Allele
     multivalued: false
-
-  single_construct:
-    domain: ConstructComponentSlotAnnotation
-    range: Construct
-    multivalued: false
-
-  taxon_text:
-    description: >-
-      The free text reference to a species or general taxon (e.g. "Yeast") for a
-      a biological entity for which the exact taxon curie is unknown or unavailable.
 
   transgene_chromosome_location:
     description: >-

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -139,7 +139,6 @@ classes:
 
   Construct:
     is_a: Reagent
-    description: >-
     slots:
       - construct_genomic_entity_associations
       - construct_components
@@ -152,10 +151,14 @@ classes:
         required: true
 
   ConstructDTO:
-    is_a: GenomicEntityDTO
+    is_a: ReagentDTO
     slots:
+      - name
       - construct_component_dtos
       - reference_curies
+    slot_usage:
+      name:
+        required: true
 
 # TO DO: create ConstructComponentDTO and ConstructComponentAssociationDTO classes? [CG]
 
@@ -179,6 +182,14 @@ classes:
       taxon_text:
         required: false
 
+  ConstructComponentSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
+    slots:
+      - component_symbol
+      - note_dtos
+      - taxon_curie
+      - taxon_text
+
   ConstructGenomicEntityAssociation:
     is_a: Association
     description: >-
@@ -200,6 +211,22 @@ classes:
         range: GenomicEntity
       related_notes:
         required: false
+
+  ConstructGenomicEntityAssociationDTO:
+    is_a: AuditedObjectDTO
+    description: >-
+      Ingest class for association between a construct component that is a known genomic
+      entity with a curie and any accompanying meta data about the relationship between
+      the construct and that genomic entity component
+    slots:
+      - construct_curie
+      - genomic_entity_relation_name
+      - genomic_entity_curie
+      - note_dtos
+      - evidence_curies
+    slot_usage:
+      genomic_entity_curie:
+        required: true
 
   GenerationMethod:
     is_a: AuditedObject
@@ -923,8 +950,8 @@ slots:
     range: string # CV 'Chemical Mutagens'
 
   component_symbol:
-    domain: ConstructComponentSlotAnnotation
     range: string
+    required: true
     description: >-
       The free text of a symbol or name of a construct
       component for which no curie exists or is available
@@ -937,7 +964,7 @@ slots:
   construct_component_dtos:
     multivalued: true
     domain: ConstructDTO
-    range: GenomicEntityDTO
+    range: ConstructComponentSlotAnnotationDTO
     inlined: true
     inlined_as_list: true
 
@@ -987,6 +1014,14 @@ slots:
     range: GenerationMethodDTO
     multivalued: false
     inlined: true
+
+  genomic_entity_relation_name:
+    description: >-
+      Name of the VocabularyTerm describing the relationship between
+      Construct and GenomicEntity
+    domain: ConstructGenomicEntityAssociationDTO
+    range: string
+    required: true
 
   germline_transmission_status:
     description: >-

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -16,13 +16,13 @@ imports:
   - reagent
 
 prefixes:
-  alliance: 'http://alliancegenome.org/'
-  linkml: 'https://w3id.org/linkml/'
-  gff: 'https://w3id.org/gff'
-  faldo: 'http://biohackathon.org/resource/faldo#'
-  biolink: 'https://w3id.org/biolink/vocab/'
-  NLMID: 'https://www.ncbi.nlm.nih.gov/nlmcatalog/?term='
-  schema: 'http://schema.org/'
+  alliance: "http://alliancegenome.org/"
+  linkml: "https://w3id.org/linkml/"
+  gff: "https://w3id.org/gff"
+  faldo: "http://biohackathon.org/resource/faldo#"
+  biolink: "https://w3id.org/biolink/vocab/"
+  NLMID: "https://www.ncbi.nlm.nih.gov/nlmcatalog/?term="
+  schema: "http://schema.org/"
 
 default_prefix: alliance
 default_range: string
@@ -42,7 +42,6 @@ emit_prefixes:
 ## ------------
 ## CLASSES
 ## ------------
-
 
 classes:
 
@@ -85,7 +84,7 @@ classes:
     exact_mappings:
       - SO:0001023
     slot_usage:
-      aberration:    # This slot is no longer declared in the Allele class; is this covered by something else? [CG]
+      aberration: # This slot is no longer declared in the Allele class; is this covered by something else? [CG]
         notes: specific to FB
       allele_symbol:
         required: true
@@ -125,8 +124,8 @@ classes:
       note_dtos:
         notes: note_type CV 'Allele Related Note Type'
 
-# Some classes roughly grouped with the Allele class because they have relationships to Allele and were
-# designed close to the time the Allele class was designed.  These could be broken out into their own yaml files.
+  # Some classes roughly grouped with the Allele class because they have relationships to Allele and were
+  # designed close to the time the Allele class was designed.  These could be broken out into their own yaml files.
 
   CellLine:
     is_a: GenomicEntity
@@ -245,7 +244,7 @@ classes:
       - chemical_mutagen_name
       - irradiation_mutagen_name
 
-# Need to add appropriate name synonym slotAnnotations as slots removed from GenomicEntity
+  # Need to add appropriate name synonym slotAnnotations as slots removed from GenomicEntity
   SequenceTargetingReagent:
     description: >-
     is_a: GenomicEntity
@@ -276,12 +275,11 @@ classes:
       object:
         range: Gene
 
-# TO DO: create SequenceTargetingReagentToGeneAssociationDTO class? [CG]
+  # TO DO: create SequenceTargetingReagentToGeneAssociationDTO class? [CG]
 
-
-## ------------
-## ALLELE SLOT ANNOTATION CLASSES
-## ------------
+  ## ------------
+  ## ALLELE SLOT ANNOTATION CLASSES
+  ## ------------
 
   AlleleDatabaseStatusSlotAnnotation:
     is_a: SlotAnnotation
@@ -308,7 +306,7 @@ classes:
         required: true
       name_type:
         notes: >-
-            permissible_values: full_name (VocabularyTerm)
+          permissible_values: full_name (VocabularyTerm)
 
   AlleleFunctionalImpactSlotAnnotation:
     is_a: SlotAnnotation
@@ -465,9 +463,9 @@ classes:
       single_allele:
         required: true
 
-## ------------
-## ALLELE ASSOCIATION CLASSES
-## ------------
+  ## ------------
+  ## ALLELE ASSOCIATION CLASSES
+  ## ------------
 
   AlleleAlleleAssociation:
     is_a: AlleleGenomicEntityAssociation
@@ -486,7 +484,7 @@ classes:
     slots:
       - object_allele_curie
 
-# do mutant/parent/embryonic cell line associations need to be split out?
+  # do mutant/parent/embryonic cell line associations need to be split out?
   AlleleCellLineAssociation:
     is_a: Association
     description: >-
@@ -502,16 +500,16 @@ classes:
         range: CellLine
 
   AlleleCellLineAssociationDTO:
-      is_a: AuditedObjectDTO
-      description: >-
-        The relationship between an allele and a cell line.  Includes mutant/
-        embryonic stem cell lines known to carry the allele, and parental cell
-        line of alleles made in embryonic stem cells.
-      slots:
-        - allele_curie
-        - predicate_name
-        - cell_line_curie
-        - evidence_curies
+    is_a: AuditedObjectDTO
+    description: >-
+      The relationship between an allele and a cell line.  Includes mutant/
+      embryonic stem cell lines known to carry the allele, and parental cell
+      line of alleles made in embryonic stem cells.
+    slots:
+      - allele_curie
+      - predicate_name
+      - cell_line_curie
+      - evidence_curies
 
   AlleleConstructAssociation:
     is_a: AlleleGenomicEntityAssociation
@@ -530,17 +528,17 @@ classes:
         range: Construct
 
   AlleleConstructAssociationDTO:
-      is_a: AlleleGenomicEntityAssociationDTO
-      description: >-
-        The relationship between an allele and constructs contained in
-        that allele.
-      slots:
-        - construct_curie
-      slot_usage:
-        predicate_name:
-          notes: >-
-            CV 'Allele-Construct Predicates' including - contains, contains_coinjection_marker,
-            contains_phenotypic_sequence_feature, and contains_innocuous_sequence_feature
+    is_a: AlleleGenomicEntityAssociationDTO
+    description: >-
+      The relationship between an allele and constructs contained in
+      that allele.
+    slots:
+      - construct_curie
+    slot_usage:
+      predicate_name:
+        notes: >-
+          CV 'Allele-Construct Predicates' including - contains, contains_coinjection_marker,
+          contains_phenotypic_sequence_feature, and contains_innocuous_sequence_feature
 
   AlleleGeneAssociation:
     is_a: AlleleGenomicEntityAssociation
@@ -597,11 +595,11 @@ classes:
       subject:
         range: Allele
       predicate:
-        range: VocabularyTerm  # If we can adequately represent all needed relations in RO, this could be ROTerm
+        range: VocabularyTerm # If we can adequately represent all needed relations in RO, this could be ROTerm
       object:
         range: GenomicEntity
       evidence:
-        required: false   # This needs to be not required, at least in the base class
+        required: false # This needs to be not required, at least in the base class
 
   AlleleGenomicEntityAssociationDTO:
     is_a: AuditedObjectDTO
@@ -655,10 +653,10 @@ classes:
     description: >-
       The relationship between an allele and the origin of the allele.
     slot_usage:
-        subject:
-            range: Allele
-        object:
-            range: AffectedGenomicModel
+      subject:
+        range: Allele
+      object:
+        range: AffectedGenomicModel
 
   AlleleOriginAssociationDTO:
     is_a: AuditedObjectDTO
@@ -726,8 +724,7 @@ classes:
 ## ------------
 
 slots:
-
-# This slot is currently not being used 2022-12-20; should it be? [CG]
+  # This slot is currently not being used 2022-12-20; should it be? [CG]
   aberration:
     description: >-
       Associated deficiency (etc.) whose breakpoint causes
@@ -821,7 +818,7 @@ slots:
     multivalued: true
 
   allele_inheritance_modes:
-    description:  >-
+    description: >-
       Inheritance modes for an allele
     domain: Allele
     range: AlleleInheritanceModeSlotAnnotation
@@ -927,7 +924,7 @@ slots:
     range: AlleleVariantAssociation
     multivalued: true
 
-# This slot is currently not being used 2022-12-20; should it be? [CG]
+  # This slot is currently not being used 2022-12-20; should it be? [CG]
   analyses:
     description: >-
       TODO: added as a result of 'origin' class - please advise on a more descriptive slot/class definition.
@@ -962,7 +959,6 @@ slots:
 
   construct_component_dtos:
     multivalued: true
-    domain: ConstructDTO
     range: ConstructComponentSlotAnnotationDTO
     inlined: true
     inlined_as_list: true
@@ -1071,14 +1067,14 @@ slots:
     description: >-
       WormBase captures the method by which an extrachromosomal transgene was integrated into the genome.
     domain: GenerationMethod
-    range: VocabularyTerm  #CV 'WB Transgene Integration Method'
+    range: VocabularyTerm #CV 'WB Transgene Integration Method'
     multivalued: false
 
   integration_method_name:
     description: >-
       WormBase captures the method by which an extrachromosomal transgene was integrated into the genome.
     domain: GenerationMethodDTO
-    range: string  #CV 'WB Transgene Integration Methods'
+    range: string #CV 'WB Transgene Integration Methods'
     multivalued: false
 
   irradiation_mutagen:
@@ -1232,16 +1228,14 @@ slots:
     range: string
     multivalued: false
 
-  transposon_insertion:   # This slot is currently not being used 2022-12-20; should it be? [CG]
+  transposon_insertion: # This slot is currently not being used 2022-12-20; should it be? [CG]
     description: >-
       Associated transposon insertion that causes the
       mutation
     domain: Allele
     range: string
 
-
 enums:
-
   sqtr_relation_enum:
     permissible_values:
       targets:

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -160,8 +160,6 @@ classes:
       name:
         required: true
 
-# TO DO: create ConstructComponentDTO and ConstructComponentAssociationDTO classes? [CG]
-
   ConstructComponentSlotAnnotation:
     is_a: SlotAnnotation
     slots:

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -13,6 +13,7 @@ imports:
   - linkml:types
   - ontologyTerm
   - phenotypeAndDiseaseAnnotation
+  - reagent
 
 prefixes:
   alliance: 'http://alliancegenome.org/'

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -444,7 +444,7 @@ classes:
       The relationship between an allele and constructs contained in
       that allele.
     slots:
-      - construct_curie
+      - construct_identifier
     slot_usage:
       predicate_name:
         notes: >-

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -1,4 +1,4 @@
-id: https://github.com/alliance-genome/agr_curation_schema/src/schema/allele
+id: https://github.com/alliance-genome/agr_curation_schema/src/schema/allele.yaml
 name: allele
 title: Allele
 

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -424,6 +424,12 @@ classes:
 
 slots:
 
+  name:
+    description: >-
+      a human-readable name for an entity
+    multivalued: false
+    range: string
+  
   name_type:
     description: >-
       The type of name: e.g., symbol, full_name, systematic_name, etc.

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -264,6 +264,8 @@ classes:
     slots:
       - linkml_version
       - allele_ingest_set
+      - construct_ingest_set
+      - construct_genomic_entity_association_ingest_set
       - disease_allele_ingest_set
       - disease_agm_ingest_set
       - disease_gene_ingest_set

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -179,7 +179,7 @@ slots:
       An ingest set for ConstructGenomicEntityAssociationDTO
     domain: Ingest
     range: ConstructGenomicEntityAssociationDTO
-    multivaluted: true
+    multivalued: true
     mixins:
       - object_set
 

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -12,6 +12,7 @@ imports:
   - affectedGenomicModel
   - phenotypeAndDiseaseAnnotation
   - allele
+  - reagent
 
 prefixes:
   alliance: 'http://alliancegenome.org/'

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -11,6 +11,7 @@ imports:
   - ontologyTerm
   - affectedGenomicModel
   - phenotypeAndDiseaseAnnotation
+  - allele
 
 prefixes:
   alliance: 'http://alliancegenome.org/'

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -4,6 +4,7 @@ title: Alliance Schema Ingest
 
 imports:
   - core
+  - reagent
   - allele
   - gene
   - image

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -4,6 +4,7 @@ title: Alliance Schema Ingest
 
 imports:
   - core
+  - allele
   - gene
   - image
   - variation
@@ -11,8 +12,6 @@ imports:
   - ontologyTerm
   - affectedGenomicModel
   - phenotypeAndDiseaseAnnotation
-  - allele
-  - reagent
 
 prefixes:
   alliance: 'http://alliancegenome.org/'
@@ -117,7 +116,6 @@ slots:
     mixins:
       - object_set
 
-
   allele_cell_line_association_ingest_set:
     domain: Ingest
     range: AlleleCellLineAssociationDTO
@@ -155,19 +153,19 @@ slots:
     mixins:
       - object_set
 
-  construct_ingest_set:
-    description: An ingest set for Constructs
-    domain: Ingest
-    range: ConstructDTO
-    multivalued: true
-    mixins:
-      - object_set
-
   construct_genomic_entity_association_ingest_set:
     description: >-
       An ingest set for ConstructGenomicEntityAssociationDTO
     domain: Ingest
     range: ConstructGenomicEntityAssociationDTO
+    multivalued: true
+    mixins:
+      - object_set
+      
+  construct_ingest_set:
+    description: An ingest set for Constructs
+    domain: Ingest
+    range: ConstructDTO
     multivalued: true
     mixins:
       - object_set

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -155,7 +155,7 @@ slots:
     mixins:
       - object_set
 
-variant_genomic_location_association_ingest_set:
+  variant_genomic_location_association_ingest_set:
     description: >-
     domain: Ingest
     range: VariantGenomicLocationAssociationDTO

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -166,6 +166,23 @@ slots:
     mixins:
       - object_set
 
+  construct_ingest_set:
+    description: An ingest set for Constructs
+    domain: Ingest
+    range: ConstructDTO
+    multivalued: true
+    mixins:
+      - object_set
+
+  construct_genomic_entity_association_ingest_set:
+    description: >-
+      An ingest set for ConstructGenomicEntityAssociationDTO
+    domain: Ingest
+    range: ConstructGenomicEntityAssociationDTO
+    multivaluted: true
+    mixins:
+      - object_set
+
   disease_allele_ingest_set:
     description: >-
     domain: Ingest

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -54,7 +54,6 @@ slots:
     required: true
 
   allele_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleDTO
     multivalued: true
@@ -62,7 +61,6 @@ slots:
       - object_set
 
   agm_ingest_set:
-    description: >-
     domain: Ingest
     range: AffectedGenomicModelDTO
     multivalued: true
@@ -70,7 +68,6 @@ slots:
       - object_set
 
   sqtr_ingest_set:
-    description: >-
     domain: Ingest
     range: SequenceTargetingReagentDTO
     multivalued: true
@@ -78,7 +75,6 @@ slots:
       - object_set
 
   variant_ingest_set:
-    description: >-
     domain: Ingest
     range: Variant
     multivalued: true
@@ -86,7 +82,6 @@ slots:
       - object_set
 
   allele_variant_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleVariantAssociationDTO
     multivalued: true
@@ -94,7 +89,6 @@ slots:
       - object_set
 
   allele_gene_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleGeneAssociationDTO
     multivalued: true
@@ -102,7 +96,6 @@ slots:
       - object_set
 
   allele_transcript_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleTranscriptAssociationDTO
     multivalued: true
@@ -110,7 +103,6 @@ slots:
       - object_set
 
   allele_protein_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleProteinAssociationDTO
     multivalued: true
@@ -118,7 +110,6 @@ slots:
       - object_set
 
   allele_construct_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleConstructAssociationDTO
     multivalued: true
@@ -127,7 +118,6 @@ slots:
 
 
   allele_cell_line_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleCellLineAssociationDTO
     multivalued: true
@@ -135,7 +125,6 @@ slots:
       - object_set
 
   allele_origin_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleOriginAssociationDTO
     multivalued: true
@@ -143,7 +132,6 @@ slots:
       - object_set
 
   allele_generation_method_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleGenerationMethodAssociationDTO
     multivalued: true
@@ -151,7 +139,6 @@ slots:
       - object_set
 
   allele_image_association_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleImageAssociationDTO
     multivalued: true
@@ -185,7 +172,6 @@ slots:
       - object_set
 
   disease_allele_ingest_set:
-    description: >-
     domain: Ingest
     range: AlleleDiseaseAnnotationDTO
     multivalued: true
@@ -193,7 +179,6 @@ slots:
       - object_set
 
   disease_agm_ingest_set:
-    description: >-
     domain: Ingest
     range: AGMDiseaseAnnotationDTO
     multivalued: true
@@ -201,7 +186,6 @@ slots:
       - object_set
 
   disease_gene_ingest_set:
-    description: >-
     domain: Ingest
     range: GeneDiseaseAnnotationDTO
     multivalued: true
@@ -209,7 +193,6 @@ slots:
       - object_set
 
   ontology_closure_ingest_set:
-    description: >-
     domain: Ingest
     range: OntologyTermClosure
     multivalued: true
@@ -217,7 +200,6 @@ slots:
       - object_set
 
   gene_ingest_set:
-    description: >-
     domain: Ingest
     range: GeneDTO
     multivalued: true
@@ -225,7 +207,6 @@ slots:
       - object_set
 
   phenotype_allele_ingest_set:
-    description: >-
     domain: Ingest
     range: AllelePhenotypeAnnotationDTO
     multivalued: true
@@ -233,7 +214,6 @@ slots:
       - object_set
 
   phenotype_agm_ingest_set:
-    description: >-
     domain: Ingest
     range: AGMPhenotypeAnnotationDTO
     multivalued: true
@@ -241,7 +221,6 @@ slots:
       - object_set
 
   phenotype_gene_ingest_set:
-    description: >-
     domain: Ingest
     range: GenePhenotypeAnnotationDTO
     multivalued: true
@@ -253,7 +232,7 @@ slots:
     domain: Ingest
     multivalued: true
     inlined_as_list: true
-    description:
+    description: >-
       Applies to a property that links a ingest object to a set of objects.
       This is necessary in a json document to provide context for a list, and
       to allow for a single json object that combines multiple object types

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -85,6 +85,7 @@ classes:
       - reference_curie
       - note_dtos
       - data_provider_dto
+      - condition_relation_dtos
 
   PhenotypeAnnotation:
     is_a: Annotation
@@ -336,7 +337,6 @@ classes:
       - annotation_type_name
       - with_gene_curies
       - disease_qualifier_names
-      - condition_relation_dtos
       - genetic_sex_name
       - secondary_data_provider_dto
       - disease_genetic_modifier_curies

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -62,7 +62,6 @@ classes:
       - mod_internal_id
       - subject
       - object
-      - relation
       - single_reference
       - condition_relations
       - related_notes
@@ -288,7 +287,7 @@ classes:
         description: >-
           The disease ontology term.
         range: DOTerm
-      relation:
+      disease_relation:
         description: >-
           The relation between the subject biological entity and disease in the annotation.
           Permissible values are terms from the CV 'Disease Relation Vocabulary'
@@ -356,7 +355,7 @@ classes:
         description: >-
           The gene to which the disease ontology term is associated.
         range: Gene
-      relation:
+      disease_relation:
         description: >-
           The relationship between gene and disease. Submitted value should be a
           vocabulary term from the 'Gene disease relations' vocabulary
@@ -384,7 +383,7 @@ classes:
         description: >-
           The allele to which the disease ontology term is associated.
         range: Allele
-      relation:
+      disease_relation:
         description: >-
           The relationship between allele and disease. Submitted value should be
           a vocabulary term from the 'Allele disease relations' vocabulary
@@ -423,7 +422,7 @@ classes:
         description: >-
           The AGM to which the disease ontology term is associated.
         range: AffectedGenomicModel
-      relation:
+      disease_relation:
         description: >-
           The relationship between AGM and disease. Submitted value should be a
           vocabulary term from the 'AGM disease relations' vocabulary
@@ -783,12 +782,13 @@ slots:
     range: string # CV 'Disease qualifiers'
     multivalued: true
 
-  relation:
+  disease_relation:
     description: >-
-      Relationship between subject and object described
+      Relationship between subject and disease described
       by the annotation
     domain: DiseaseAnnotation
     range: VocabularyTerm
+    required: true
 
   genetic_sex:
     description: >-

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -47,6 +47,9 @@ classes:
       A material entity used in experiments.
     slots:
       - curie
+      - unique_id
+      - mod_entity_id
+      - mod_internal_id
       - taxon
       - generated_by
       - manufactured_by
@@ -56,10 +59,14 @@ classes:
     description: >-
       Ingest class for material entities used in experiments.
     slots:
-      - curie
+      - mod_entity_id
+      - mod_internal_id
       - taxon_curie
       - generated_by_identifier # needs to change: currently no common identifier field for Agent class
       - manufactured_by_identifier # needs to change: currently no common identifier field for Agent class
+    slot_usage:
+      mod_internal_id:
+        notes: This is required if mod_entity_id is not submitted
 
   Antibody:
     is_a: Reagent
@@ -198,7 +205,7 @@ classes:
       entity with a curie and any accompanying meta data about the relationship between
       the construct and that genomic entity component
     slots:
-      - construct_curie
+      - construct_identifier
       - genomic_entity_relation_name
       - genomic_entity_curie
       - note_dtos
@@ -263,15 +270,18 @@ slots:
     inlined: true
     inlined_as_list: true
 
-  construct_curie:
-    range: string
-    required: true
-
   construct_genomic_entity_associations:
     multivalued: true
     domain: Construct
     range: ConstructGenomicEntityAssociation
 
+  construct_identifier:
+    description: >-
+      Either the MOD curie or internal ID that was used in the submission
+      of the associated construct
+    range: string
+    required: true
+  
   generated_by_identifier:
     description: >- 
       Identifier for Reagent genereated_by field.  

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -1,4 +1,6 @@
 id: https://github.com/alliance-genome/agr_curation_schema/src/schema/reagent.yaml
+name: reagent
+title: Reagent
 
 imports:
   - core
@@ -48,7 +50,6 @@ classes:
       - taxon
       - generated_by
       - manufactured_by
-
 
   ReagentDTO:
     is_a: AuditedObjectDTO

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -60,11 +60,6 @@ classes:
       - taxon_curie
       - generated_by_identifier # needs to change: currently no common identifier field for Agent class
       - manufactured_by_identifier # needs to change: currently no common identifier field for Agent class
-    slot_usage:
-      curie:
-        required: true
-      taxon_curie:
-        required: true
 
   Antibody:
     is_a: Reagent

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -123,6 +123,95 @@ classes:
           The reference providing the original description of the antibody's
           generation.
 
+  Construct:
+    is_a: Reagent
+    slots:
+      - construct_genomic_entity_associations
+      - construct_components
+      - name
+      - references
+    slot_usage:
+      curie:
+        identifier: true
+      name:
+        required: true
+
+  ConstructDTO:
+    is_a: ReagentDTO
+    slots:
+      - name
+      - construct_component_dtos
+      - reference_curies
+    slot_usage:
+      name:
+        required: true
+
+  ConstructComponentSlotAnnotation:
+    is_a: SlotAnnotation
+    slots:
+      - single_construct
+      - component_symbol
+      - related_notes
+      - taxon
+      - taxon_text
+    slot_usage:
+      single_construct:
+        required: true
+      component_symbol:
+        required: true
+      related_notes:
+        required: false
+      taxon:
+        required: false
+      taxon_text:
+        required: false
+
+  ConstructComponentSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
+    slots:
+      - component_symbol
+      - note_dtos
+      - taxon_curie
+      - taxon_text
+
+  ConstructGenomicEntityAssociation:
+    is_a: Association
+    description: >-
+      An association class to capture the identity of a construct component that is
+      a known genomic entity with a curie and any accompanying meta data about the
+      relationship between the construct and that genomic entity component
+    slots:
+      - related_notes
+    slot_usage:
+      subject:
+        range: Construct
+      predicate:
+        range: VocabularyTerm
+        notes: >-
+          The predicate should be a VocabularyTerm with one of the following
+          values - expresses (RO:0002292) / is_regulated_by (RO:0002334) /
+          targets (RO:0002436). CV: 'Construct Genomic Entity Association Predicate'
+      object:
+        range: GenomicEntity
+      related_notes:
+        required: false
+
+  ConstructGenomicEntityAssociationDTO:
+    is_a: AuditedObjectDTO
+    description: >-
+      Ingest class for association between a construct component that is a known genomic
+      entity with a curie and any accompanying meta data about the relationship between
+      the construct and that genomic entity component
+    slots:
+      - construct_curie
+      - genomic_entity_relation_name
+      - genomic_entity_curie
+      - note_dtos
+      - evidence_curies
+    slot_usage:
+      genomic_entity_curie:
+        required: true
+
   # If we need to have multiple paths to root class, then we can consider a mixin that allows
   # DNA|RNAClones to be classified independently from Reagents.
 
@@ -161,12 +250,46 @@ slots:
     domain: Antibody
     range: antibody_clonality_set
 
+  component_symbol:
+    range: string
+    required: true
+    description: >-
+      The free text of a symbol or name of a construct
+      component for which no curie exists or is available
+
+  construct_components:
+    multivalued: true
+    domain: Construct
+    range: ConstructComponentSlotAnnotation
+
+  construct_component_dtos:
+    multivalued: true
+    range: ConstructComponentSlotAnnotationDTO
+    inlined: true
+    inlined_as_list: true
+
+  construct_curie:
+    range: string
+    required: true
+
+  construct_genomic_entity_associations:
+    multivalued: true
+    domain: Construct
+    range: ConstructGenomicEntityAssociation
+
   generated_by_identifier:
     description: >- 
       Identifier for Reagent genereated_by field.  
     domain: ReagentDTO
     range: string
-
+  
+  genomic_entity_relation_name:
+    description: >-
+      Name of the VocabularyTerm describing the relationship between
+      Construct and GenomicEntity
+    domain: ConstructGenomicEntityAssociationDTO
+    range: string
+    required: true
 
   heavy_chain_isotype:
     description: >-
@@ -190,6 +313,16 @@ slots:
     domain: ReagentDTO
     range: string
     
+  single_construct:
+    domain: ConstructComponentSlotAnnotation
+    range: Construct
+    multivalued: false
+
+  taxon_text:
+    description: >-
+      The free text reference to a species or general taxon (e.g. "Yeast") for a
+      a biological entity for which the exact taxon curie is unknown or unavailable.
+
 enums:
 
   antibody_clonality_set:

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -54,6 +54,21 @@ classes:
       taxon:
         required: false
 
+  ReagentDTO:
+    is_a: AuditedObjectDTO
+    description: >-
+      Ingest class for material entities used in experiments.
+    slots:
+      - curie
+      - taxon_curie
+      - generated_by_identifier # needs to change: currently no common identifier field for Agent class
+      - manufactured_by_identifier # needs to change: currently no common identifier field for Agent class
+    slot_usage:
+      curie:
+        required: true
+      taxon_curie:
+        required: true
+
   Antibody:
     is_a: Reagent
     description: >-
@@ -149,6 +164,13 @@ slots:
     domain: Antibody
     range: antibody_clonality_set
 
+  generated_by_identifier:
+    description: >- 
+      Identifier for Reagent genereated_by field.  
+    domain: ReagentDTO
+    range: string
+
+
   heavy_chain_isotype:
     description: >-
       The isotype of the antibody heavy chain: e.g., IgA.
@@ -165,6 +187,12 @@ slots:
     domain: Antibody
     range: light_chain_isotype_set
 
+  manufactured_by_identifier:
+    description: >- 
+      Identifier for Reagent manufactured_by field.  
+    domain: ReagentDTO
+    range: string
+    
 enums:
 
   antibody_clonality_set:

--- a/test/data/allele_association_ingest_test.json
+++ b/test/data/allele_association_ingest_test.json
@@ -122,7 +122,7 @@
     {
       "allele_curie": "WB:WBVar00000001",
       "predicate_name": "has_construct",
-      "construct_curie": "WB:WBConstruct00000001",
+      "construct_identifier": "WB:WBConstruct00000001",
       "evidence_code_curie": "ECO:0000006",
       "evidence_curies": [
         "PMID:11231512"

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -10,7 +10,7 @@
       "name": "Construct A",
       "taxon_curie": "NCBITaxon:6239",
       "generated_by_identifier": "WB:WBLaboratory123",
-      "manufatured_by_identifier": "Construct Corps",
+      "manufactured_by_identifier": "Construct Corps",
       "reference_curies": [
         "PMID:101231321"
       ],
@@ -25,7 +25,8 @@
               "note_type_name": "comment",
               "internal": false
             }
-          ]
+          ],
+          "internal": false
         }
       ]
     }

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -1,0 +1,56 @@
+{
+  "linkml_version": "1.8.0",
+  "construct_ingest_set": [
+    {
+      "created_by_curie": "WB:WBPerson123",
+      "updated_by_curie": "WB:WBPerson123",
+      "internal": false,
+      "obsolete": false,
+      "curie": "WB:WBConstruct123",
+      "name": "Construct A",
+      "taxon_curie": "NCBITaxon:6239",
+      "generated_by_identifier": "WB:WBLaboratory123",
+      "manufatured_by_identifier": "Construct Corps",
+      "reference_curies": [
+        "PMID:101231321"
+      ],
+      "construct_component_dtos": [
+        {
+          "component_symbol": "comA",
+          "taxon_curie": "NCBITaxon:6239",
+          "taxon_text": "Caenorhabditis elegans",
+          "note_dtos": [
+            {
+              "free_text": "some text about stuff",
+              "note_type_name": "comment",
+              "internal": false
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "construct_genomic_entity_association_ingest_set": [
+    {
+      "construct_curie": "WB:WBConstruct123",
+      "genomic_entity_relation_name": "is_regulated_by",
+      "genomic_entity_curie": "WB:WBGene00000001",
+      "evidence_curies": [
+        "PMID:11231512"
+      ],
+      "note_dtos": [
+        {
+          "free_text": "note about association",
+          "note_type_name": "comment",
+          "internal": false
+        }
+      ],
+      "internal": false,
+      "obsolete": false,
+      "date_created": "2015-04-09T10:15:30+00:00",
+      "date_updated": "2022-07-11T13:12:51+00:00",
+      "created_by_curie": "WB:WBPerson002314",
+      "updated_by_curie": "WB:WBPerson010002"
+    }
+  ]
+}

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -6,7 +6,7 @@
       "updated_by_curie": "WB:WBPerson123",
       "internal": false,
       "obsolete": false,
-      "curie": "WB:WBConstruct123",
+      "mod_entity_id": "WB:WBConstruct123",
       "name": "Construct A",
       "taxon_curie": "NCBITaxon:6239",
       "generated_by_identifier": "WB:WBLaboratory123",
@@ -33,7 +33,7 @@
   ],
   "construct_genomic_entity_association_ingest_set": [
     {
-      "construct_curie": "WB:WBConstruct123",
+      "construct_identifier": "WB:WBConstruct123",
       "genomic_entity_relation_name": "is_regulated_by",
       "genomic_entity_curie": "WB:WBGene00000001",
       "evidence_curies": [


### PR DESCRIPTION
There are currently a couple of slots that may need to change (`generated_by_identifier` and `manufacture_by_identifier`).  The non-DTO versions of these slots have a range of `Agent`, but there is no common identifying field for `Agent`: the `Person` class has `unique_id`, `Laboratory` has `curie`, `Company` and `Organization` don't have any identifier.  We will need to resolve this in the modelling of the Agent class and subclasses and then update these two field names to be something more descriptive.