### PR TITLE
Add data provider to Reagent class

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -4980,6 +4980,10 @@
                     "description": "A unique identifier for the antibody: e.g., WBAntibody0000001.",
                     "type": "string"
                 },
+                "data_provider": {
+                    "$ref": "#/$defs/DataProvider",
+                    "description": "Object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
+                },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
                     "format": "date-time",
@@ -5086,6 +5090,7 @@
                 "name",
                 "clonality",
                 "curie",
+                "data_provider",
                 "internal"
             ],
             "title": "Antibody",
@@ -5119,6 +5124,10 @@
                         "$ref": "#/$defs/CrossReferenceDTO"
                     },
                     "type": "array"
+                },
+                "data_provider_dto": {
+                    "$ref": "#/$defs/DataProviderDTO",
+                    "description": "Ingest object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
                 },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
@@ -5211,6 +5220,7 @@
             "required": [
                 "name",
                 "clonality_name",
+                "data_provider_dto",
                 "internal"
             ],
             "title": "AntibodyDTO",
@@ -7107,6 +7117,10 @@
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
                 },
+                "data_provider": {
+                    "$ref": "#/$defs/DataProvider",
+                    "description": "Object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
+                },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
                     "format": "date-time",
@@ -7184,6 +7198,7 @@
             "required": [
                 "name",
                 "curie",
+                "data_provider",
                 "internal"
             ],
             "title": "Construct",
@@ -7354,6 +7369,10 @@
                     "description": "Curie of the Person object representing the individual that created the entity",
                     "type": "string"
                 },
+                "data_provider_dto": {
+                    "$ref": "#/$defs/DataProviderDTO",
+                    "description": "Ingest object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
+                },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
                     "format": "date-time",
@@ -7420,6 +7439,7 @@
             },
             "required": [
                 "name",
+                "data_provider_dto",
                 "internal"
             ],
             "title": "ConstructDTO",
@@ -8023,6 +8043,10 @@
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
                 },
+                "data_provider": {
+                    "$ref": "#/$defs/DataProvider",
+                    "description": "Object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
+                },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
                     "format": "date-time",
@@ -8088,6 +8112,7 @@
             },
             "required": [
                 "curie",
+                "data_provider",
                 "internal"
             ],
             "title": "DNAClone",
@@ -16456,6 +16481,10 @@
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
                 },
+                "data_provider": {
+                    "$ref": "#/$defs/DataProvider",
+                    "description": "Object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
+                },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
                     "format": "date-time",
@@ -16521,6 +16550,7 @@
             },
             "required": [
                 "curie",
+                "data_provider",
                 "internal"
             ],
             "title": "RNAClone",
@@ -16772,6 +16802,10 @@
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
                 },
+                "data_provider": {
+                    "$ref": "#/$defs/DataProvider",
+                    "description": "Object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
+                },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
                     "format": "date-time",
@@ -16837,6 +16871,7 @@
             },
             "required": [
                 "curie",
+                "data_provider",
                 "internal"
             ],
             "title": "Reagent",
@@ -16849,6 +16884,10 @@
                 "created_by_curie": {
                     "description": "Curie of the Person object representing the individual that created the entity",
                     "type": "string"
+                },
+                "data_provider_dto": {
+                    "$ref": "#/$defs/DataProviderDTO",
+                    "description": "Ingest object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
                 },
                 "date_created": {
                     "description": "The date on which an entity was created. This can be applied to nodes or edges.",
@@ -16904,6 +16943,7 @@
                 }
             },
             "required": [
+                "data_provider_dto",
                 "internal"
             ],
             "title": "ReagentDTO",

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -53,6 +53,7 @@ classes:
       - taxon
       - generated_by
       - manufactured_by
+      - data_provider
 
   ReagentDTO:
     is_a: AuditedObjectDTO
@@ -64,6 +65,7 @@ classes:
       - taxon_curie
       - generated_by_identifier # needs to change: currently no common identifier field for Agent class
       - manufactured_by_identifier # needs to change: currently no common identifier field for Agent class
+      - data_provider_dto
     slot_usage:
       mod_internal_id:
         notes: This is required if mod_entity_id is not submitted

--- a/test/data/antibody_test.json
+++ b/test/data/antibody_test.json
@@ -43,7 +43,18 @@
           "note_type_name": "antibody_description",
           "internal": false
         }
-      ]
+      ],
+      "data_provider_dto": {
+        "source_organization_abbreviation": "WB",
+        "cross_reference_dto": {
+          "referenced_curie": "WB:WBAntibody123",
+          "prefix": "WB",
+          "page_area": "construct",
+          "display_name": "WB:WBAntibody123",
+          "internal": false
+        },
+        "internal": false
+      }
     }
   ]
 }

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -28,7 +28,18 @@
           ],
           "internal": false
         }
-      ]
+      ],
+      "data_provider_dto": {
+        "source_organization_abbreviation": "WB",
+        "cross_reference_dto": {
+          "referenced_curie": "WB:WBConstruct123",
+          "prefix": "WB",
+          "page_area": "construct",
+          "display_name": "WB:WBConstruct123",
+          "internal": false
+        },
+        "internal": false
+      }
     }
   ],
   "construct_genomic_entity_association_ingest_set": [


### PR DESCRIPTION
@chris-grove Constructs (and presumably other reagents) are going to be a submitted datatype.  As such, we will need data_provider for cleanup purposes.