### PR TITLE
Add synonyms, 2ndary IDs, XREFs to Reagent

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -13251,6 +13251,10 @@
                     },
                     "type": "array"
                 },
+                "alliance_member_release_version": {
+                    "description": "Version of Alliance member/MOD release used for submitted file",
+                    "type": "string"
+                },
                 "antibody_ingest_set": {
                     "description": "An ingest set for Antibody objects",
                     "items": {
@@ -22442,6 +22446,10 @@
                 "$ref": "#/$defs/AlleleVariantAssociationDTO"
             },
             "type": "array"
+        },
+        "alliance_member_release_version": {
+            "description": "Version of Alliance member/MOD release used for submitted file",
+            "type": "string"
         },
         "antibody_ingest_set": {
             "description": "An ingest set for Antibody objects",

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -5065,13 +5065,6 @@
                     },
                     "type": "array"
                 },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
                 "taxon": {
                     "description": "The species in which the antibody was raised: e.g., mouse, rabbit, guinea pig, goat, camel, etc.",
                     "type": "string"
@@ -5202,13 +5195,6 @@
                     "type": "array"
                 },
                 "secondary_identifiers": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -7109,6 +7095,13 @@
                     },
                     "type": "array"
                 },
+                "construct_synonyms": {
+                    "description": "Holds between an Construct and a synonym.",
+                    "items": {
+                        "$ref": "#/$defs/ConstructSynonymSlotAnnotation"
+                    },
+                    "type": "array"
+                },
                 "created_by": {
                     "description": "The individual that created the entity.",
                     "type": "string"
@@ -7190,13 +7183,6 @@
                     "type": "array"
                 },
                 "secondary_identifiers": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -7385,6 +7371,12 @@
                     },
                     "type": "array"
                 },
+                "construct_synonym_dtos": {
+                    "items": {
+                        "$ref": "#/$defs/NameSlotAnnotationDTO"
+                    },
+                    "type": "array"
+                },
                 "created_by_curie": {
                     "description": "Curie of the Person object representing the individual that created the entity",
                     "type": "string"
@@ -7455,13 +7447,6 @@
                     "type": "array"
                 },
                 "secondary_identifiers": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -7625,6 +7610,87 @@
                 "internal"
             ],
             "title": "ConstructGenomicEntityAssociationDTO",
+            "type": "object"
+        },
+        "ConstructSynonymSlotAnnotation": {
+            "additionalProperties": false,
+            "description": "All aliases (non-preferred names) for the construct. Any type of synonym is acceptable.",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "display_text": {
+                    "description": "A version of a synonym string for display. Any UTF8 character is permitted.",
+                    "type": "string"
+                },
+                "evidence": {
+                    "description": "",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "format_text": {
+                    "description": "A version of a synonym string using only ASCII characters, which is easier to type (for searches), print and parse. For example, Greek characters are transliterated.",
+                    "type": "string"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name_type": {
+                    "description": "The type of name: e.g., symbol, full_name, systematic_name, etc.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "single_construct": {
+                    "type": "string"
+                },
+                "synonym_scope": {
+                    "description": "the scope of the synonym - permissible values are narrow / broad / related / exact",
+                    "type": "string"
+                },
+                "synonym_url": {
+                    "description": "URL for a synonym: e.g., NCBI URL for the NCBI synonym of an object.",
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "single_construct",
+                "name_type",
+                "format_text",
+                "display_text",
+                "internal"
+            ],
+            "title": "ConstructSynonymSlotAnnotation",
             "type": "object"
         },
         "CrossReference": {
@@ -8144,13 +8210,6 @@
                     "type": "boolean"
                 },
                 "secondary_identifiers": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },
@@ -16526,13 +16585,6 @@
                     },
                     "type": "array"
                 },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
                 "taxon": {
                     "description": "The taxon from which the biological entity derives.",
                     "type": "string"
@@ -16867,13 +16919,6 @@
                     },
                     "type": "array"
                 },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
                 "taxon": {
                     "description": "The taxon from which the biological entity derives.",
                     "type": "string"
@@ -16958,13 +17003,6 @@
                     "type": "boolean"
                 },
                 "secondary_identifiers": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "synonyms": {
-                    "description": "A generic free-text field for objects that only have string representation of one or more synonyms and do not require meta data or attribution; if meta data or attribution are required to be captured for individual synonyms, consider the NameSlotAnnotation class",
                     "items": {
                         "type": "string"
                     },

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -7114,13 +7114,6 @@
                     "description": "The individual that created the entity.",
                     "type": "string"
                 },
-                "cross_references": {
-                    "description": "Holds between an object and its CrossReferences.",
-                    "items": {
-                        "$ref": "#/$defs/CrossReference"
-                    },
-                    "type": "array"
-                },
                 "curie": {
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
@@ -7149,23 +7142,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "generated_by": {
-                    "description": "Holds between a material entity and an Agent that generated it: e.g., Thomas Blumenthal, Kornberg Laboratory.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
-                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
-                },
-                "manufactured_by": {
-                    "description": "Holds between a material entity and an Agent that has manufactured it: e.g., Molecular Probes.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
@@ -7191,10 +7170,6 @@
                         "type": "string"
                     },
                     "type": "array"
-                },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
                 },
                 "unique_id": {
                     "description": "A non-curie unique identifier for a thing.",
@@ -7404,12 +7379,6 @@
                     "description": "Curie of the Person object representing the individual that created the entity",
                     "type": "string"
                 },
-                "cross_reference_dtos": {
-                    "items": {
-                        "$ref": "#/$defs/CrossReferenceDTO"
-                    },
-                    "type": "array"
-                },
                 "data_provider_dto": {
                     "$ref": "#/$defs/DataProviderDTO",
                     "description": "Ingest object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
@@ -7434,17 +7403,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "generated_by_identifier": {
-                    "description": "Identifier for Reagent genereated_by field.  ",
-                    "type": "string"
-                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
-                },
-                "manufactured_by_identifier": {
-                    "description": "Identifier for Reagent manufactured_by field.  ",
-                    "type": "string"
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
@@ -7470,10 +7431,6 @@
                         "type": "string"
                     },
                     "type": "array"
-                },
-                "taxon_curie": {
-                    "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
-                    "type": "string"
                 },
                 "updated_by_curie": {
                     "description": "Curie of the Person object representing the individual that updated the entity",
@@ -8325,13 +8282,6 @@
                     "description": "The individual that created the entity.",
                     "type": "string"
                 },
-                "cross_references": {
-                    "description": "Holds between an object and its CrossReferences.",
-                    "items": {
-                        "$ref": "#/$defs/CrossReference"
-                    },
-                    "type": "array"
-                },
                 "curie": {
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
@@ -8360,23 +8310,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "generated_by": {
-                    "description": "Holds between a material entity and an Agent that generated it: e.g., Thomas Blumenthal, Kornberg Laboratory.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
-                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
-                },
-                "manufactured_by": {
-                    "description": "Holds between a material entity and an Agent that has manufactured it: e.g., Molecular Probes.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
@@ -8395,10 +8331,6 @@
                         "type": "string"
                     },
                     "type": "array"
-                },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
                 },
                 "unique_id": {
                     "description": "A non-curie unique identifier for a thing.",
@@ -16699,13 +16631,6 @@
                     "description": "The individual that created the entity.",
                     "type": "string"
                 },
-                "cross_references": {
-                    "description": "Holds between an object and its CrossReferences.",
-                    "items": {
-                        "$ref": "#/$defs/CrossReference"
-                    },
-                    "type": "array"
-                },
                 "curie": {
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
@@ -16734,23 +16659,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "generated_by": {
-                    "description": "Holds between a material entity and an Agent that generated it: e.g., Thomas Blumenthal, Kornberg Laboratory.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
-                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
-                },
-                "manufactured_by": {
-                    "description": "Holds between a material entity and an Agent that has manufactured it: e.g., Molecular Probes.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
@@ -16769,10 +16680,6 @@
                         "type": "string"
                     },
                     "type": "array"
-                },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
                 },
                 "unique_id": {
                     "description": "A non-curie unique identifier for a thing.",
@@ -17033,13 +16940,6 @@
                     "description": "The individual that created the entity.",
                     "type": "string"
                 },
-                "cross_references": {
-                    "description": "Holds between an object and its CrossReferences.",
-                    "items": {
-                        "$ref": "#/$defs/CrossReference"
-                    },
-                    "type": "array"
-                },
                 "curie": {
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"
@@ -17068,23 +16968,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "generated_by": {
-                    "description": "Holds between a material entity and an Agent that generated it: e.g., Thomas Blumenthal, Kornberg Laboratory.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
-                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
-                },
-                "manufactured_by": {
-                    "description": "Holds between a material entity and an Agent that has manufactured it: e.g., Molecular Probes.",
-                    "items": {
-                        "$ref": "#/$defs/Agent"
-                    },
-                    "type": "array"
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
@@ -17103,10 +16989,6 @@
                         "type": "string"
                     },
                     "type": "array"
-                },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
                 },
                 "unique_id": {
                     "description": "A non-curie unique identifier for a thing.",
@@ -17133,12 +17015,6 @@
                     "description": "Curie of the Person object representing the individual that created the entity",
                     "type": "string"
                 },
-                "cross_reference_dtos": {
-                    "items": {
-                        "$ref": "#/$defs/CrossReferenceDTO"
-                    },
-                    "type": "array"
-                },
                 "data_provider_dto": {
                     "$ref": "#/$defs/DataProviderDTO",
                     "description": "Ingest object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
@@ -17163,17 +17039,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "generated_by_identifier": {
-                    "description": "Identifier for Reagent genereated_by field.  ",
-                    "type": "string"
-                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
-                },
-                "manufactured_by_identifier": {
-                    "description": "Identifier for Reagent manufactured_by field.  ",
-                    "type": "string"
                 },
                 "mod_entity_id": {
                     "description": "The model organism database (MOD) identifier/curie for the object",
@@ -17192,10 +17060,6 @@
                         "type": "string"
                     },
                     "type": "array"
-                },
-                "taxon_curie": {
-                    "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
-                    "type": "string"
                 },
                 "updated_by_curie": {
                     "description": "Curie of the Person object representing the individual that updated the entity",

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -7089,14 +7089,22 @@
                     },
                     "type": "array"
                 },
+                "construct_full_name": {
+                    "$ref": "#/$defs/ConstructFullNameSlotAnnotation",
+                    "description": "Holds between a Construct and a full name."
+                },
                 "construct_genomic_entity_associations": {
                     "items": {
                         "$ref": "#/$defs/ConstructGenomicEntityAssociation"
                     },
                     "type": "array"
                 },
+                "construct_symbol": {
+                    "$ref": "#/$defs/ConstructSymbolSlotAnnotation",
+                    "description": "Holds between a Construct and the one current accepted symbol"
+                },
                 "construct_synonyms": {
-                    "description": "Holds between an Construct and a synonym.",
+                    "description": "Holds between a Construct and a list of synonyms.",
                     "items": {
                         "$ref": "#/$defs/ConstructSynonymSlotAnnotation"
                     },
@@ -7167,10 +7175,6 @@
                     "description": "The model organism database (MOD) internal identifier for the object",
                     "type": "string"
                 },
-                "name": {
-                    "description": "a human-readable name for an entity",
-                    "type": "string"
-                },
                 "obsolete": {
                     "description": "Entity is no longer current.",
                     "type": "boolean"
@@ -7202,7 +7206,7 @@
                 }
             },
             "required": [
-                "name",
+                "construct_symbol",
                 "curie",
                 "data_provider",
                 "internal"
@@ -7264,6 +7268,10 @@
                     },
                     "type": "array"
                 },
+                "relation": {
+                    "description": "A high-level grouping for the relationship type. This is analogous to category for nodes. In RDF, this corresponds to rdf:predicate and in Neo4j this corresponds to the relationship type.",
+                    "type": "string"
+                },
                 "single_construct": {
                     "type": "string"
                 },
@@ -7282,6 +7290,7 @@
             },
             "required": [
                 "single_construct",
+                "relation",
                 "component_symbol",
                 "internal"
             ],
@@ -7341,6 +7350,10 @@
                     "description": "Entity is no longer current.",
                     "type": "boolean"
                 },
+                "relation_name": {
+                    "description": "Name of VocabularyTerm representing relation of an Association",
+                    "type": "string"
+                },
                 "taxon_curie": {
                     "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
                     "type": "string"
@@ -7355,6 +7368,7 @@
                 }
             },
             "required": [
+                "relation_name",
                 "component_symbol",
                 "internal"
             ],
@@ -7371,7 +7385,16 @@
                     },
                     "type": "array"
                 },
+                "construct_full_name_dto": {
+                    "$ref": "#/$defs/NameSlotAnnotationDTO",
+                    "description": "Holds between a Construct and a full name."
+                },
+                "construct_symbol_dto": {
+                    "$ref": "#/$defs/SymbolSlotAnnotationDTO",
+                    "description": "Holds between a Construct and the one current accepted symbol"
+                },
                 "construct_synonym_dtos": {
+                    "description": "Holds between a Construct and a list of synonyms.",
                     "items": {
                         "$ref": "#/$defs/NameSlotAnnotationDTO"
                     },
@@ -7431,10 +7454,6 @@
                     "description": "The model organism database (MOD) internal identifier for the object",
                     "type": "string"
                 },
-                "name": {
-                    "description": "a human-readable name for an entity",
-                    "type": "string"
-                },
                 "obsolete": {
                     "description": "Entity is no longer current.",
                     "type": "boolean"
@@ -7462,11 +7481,92 @@
                 }
             },
             "required": [
-                "name",
+                "construct_symbol_dto",
                 "data_provider_dto",
                 "internal"
             ],
             "title": "ConstructDTO",
+            "type": "object"
+        },
+        "ConstructFullNameSlotAnnotation": {
+            "additionalProperties": false,
+            "description": "The one current full name for the construct.",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "display_text": {
+                    "description": "A version of a synonym string for display. Any UTF8 character is permitted.",
+                    "type": "string"
+                },
+                "evidence": {
+                    "description": "",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "format_text": {
+                    "description": "A version of a synonym string using only ASCII characters, which is easier to type (for searches), print and parse. For example, Greek characters are transliterated.",
+                    "type": "string"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name_type": {
+                    "description": "The type of name: e.g., symbol, full_name, systematic_name, etc.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "single_construct": {
+                    "type": "string"
+                },
+                "synonym_scope": {
+                    "description": "the scope of the synonym - permissible values are narrow / broad / related / exact",
+                    "type": "string"
+                },
+                "synonym_url": {
+                    "description": "URL for a synonym: e.g., NCBI URL for the NCBI synonym of an object.",
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "single_construct",
+                "name_type",
+                "format_text",
+                "display_text",
+                "internal"
+            ],
+            "title": "ConstructFullNameSlotAnnotation",
             "type": "object"
         },
         "ConstructGenomicEntityAssociation": {
@@ -7610,6 +7710,87 @@
                 "internal"
             ],
             "title": "ConstructGenomicEntityAssociationDTO",
+            "type": "object"
+        },
+        "ConstructSymbolSlotAnnotation": {
+            "additionalProperties": false,
+            "description": "The one current symbol for the construct.",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is disinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is disinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "display_text": {
+                    "description": "A version of a synonym string for display. Any UTF8 character is permitted.",
+                    "type": "string"
+                },
+                "evidence": {
+                    "description": "",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "format_text": {
+                    "description": "A version of a synonym string using only ASCII characters, which is easier to type (for searches), print and parse. For example, Greek characters are transliterated.",
+                    "type": "string"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name_type": {
+                    "description": "The type of name: e.g., symbol, full_name, systematic_name, etc.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "single_construct": {
+                    "type": "string"
+                },
+                "synonym_scope": {
+                    "description": "the scope of the synonym - permissible values are narrow / broad / related / exact",
+                    "type": "string"
+                },
+                "synonym_url": {
+                    "description": "URL for a synonym: e.g., NCBI URL for the NCBI synonym of an object.",
+                    "type": "string"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "single_construct",
+                "name_type",
+                "format_text",
+                "display_text",
+                "internal"
+            ],
+            "title": "ConstructSymbolSlotAnnotation",
             "type": "object"
         },
         "ConstructSynonymSlotAnnotation": {

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -54,6 +54,12 @@ slots:
     range: string
     required: true
 
+  alliance_member_release_version:
+    description: >-
+      Version of Alliance member/MOD release used for submitted file
+    domain: Ingest
+    range: string
+
   allele_ingest_set:
     domain: Ingest
     range: AlleleDTO
@@ -306,6 +312,7 @@ classes:
     tree_root: true
     slots:
       - linkml_version
+      - alliance_member_release_version
       - allele_ingest_set
       - antibody_ingest_set
       - construct_ingest_set

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -50,7 +50,6 @@ classes:
       - unique_id
       - mod_entity_id
       - mod_internal_id
-      - synonyms
       - secondary_identifiers
       - cross_references
       - taxon
@@ -66,7 +65,6 @@ classes:
       - mod_entity_id
       - mod_internal_id
       - taxon_curie
-      - synonyms
       - secondary_identifiers
       - cross_reference_dtos
       - generated_by_identifier # needs to change: currently no common identifier field for Agent class
@@ -172,6 +170,7 @@ classes:
     slots:
       - construct_genomic_entity_associations
       - construct_components
+      - construct_synonyms
       - name
       - references
     slot_usage:
@@ -185,6 +184,7 @@ classes:
     slots:
       - name
       - construct_component_dtos
+      - construct_synonym_dtos
       - reference_curies
     slot_usage:
       name:
@@ -217,6 +217,16 @@ classes:
       - note_dtos
       - taxon_curie
       - taxon_text
+
+  ConstructSynonymSlotAnnotation:
+    description: >-
+      All aliases (non-preferred names) for the construct. Any type of synonym is acceptable.
+    is_a: NameSlotAnnotation
+    slots:
+      - single_construct
+    slot_usage:
+      single_construct:
+        required: true
 
   ConstructGenomicEntityAssociation:
     is_a: Association
@@ -348,7 +358,21 @@ slots:
       of the associated construct
     range: string
     required: true
-  
+
+  construct_synonyms:
+    description: Holds between an Construct and a synonym.
+    domain: Construct
+    required: false
+    multivalued: true
+    range: ConstructSynonymSlotAnnotation
+
+  construct_synonym_dtos:
+    domain: ConstructDTO
+    range: NameSlotAnnotationDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
   generated_by_identifier:
     description: >- 
       Identifier for Reagent genereated_by field.  

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -51,10 +51,6 @@ classes:
       - mod_entity_id
       - mod_internal_id
       - secondary_identifiers
-      - cross_references
-      - taxon
-      - generated_by
-      - manufactured_by
       - data_provider
 
   ReagentDTO:
@@ -64,11 +60,7 @@ classes:
     slots:
       - mod_entity_id
       - mod_internal_id
-      - taxon_curie
       - secondary_identifiers
-      - cross_reference_dtos
-      - generated_by_identifier # needs to change: currently no common identifier field for Agent class
-      - manufactured_by_identifier # needs to change: currently no common identifier field for Agent class
       - data_provider_dto
     slot_usage:
       mod_internal_id:
@@ -94,9 +86,13 @@ classes:
       - heavy_chain_isotype
       - light_chain_isotype
       - antibody_target_genes
+      - cross_references
       - references
       - original_reference
       - related_notes
+      - taxon
+      - generated_by
+      - manufactured_by
       # - disease    # Need a way to give DOID term and reference. Or a generic way to specify CV term and publication attribution.
     slot_usage:
       curie:
@@ -139,9 +135,13 @@ classes:
       - heavy_chain_isotype_name
       - light_chain_isotype_name
       - antibody_target_gene_curies
+      - cross_reference_dtos
       - reference_curies
       - original_reference_curie
       - note_dtos
+      - taxon_curie
+      - generated_by_identifier # needs to change: currently no common identifier field for Agent class
+      - manufactured_by_identifier # needs to change: currently no common identifier field for Agent class
       # - disease    # Need a way to give DOID term and reference. Or a generic way to specify CV term and publication attribution.
     slot_usage:
       name:

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -168,32 +168,35 @@ classes:
   Construct:
     is_a: Reagent
     slots:
+      - construct_symbol
+      - construct_full_name
+      - construct_synonyms
       - construct_genomic_entity_associations
       - construct_components
-      - construct_synonyms
-      - name
       - references
     slot_usage:
       curie:
         identifier: true
-      name:
+      construct_symbol:
         required: true
 
   ConstructDTO:
     is_a: ReagentDTO
     slots:
-      - name
-      - construct_component_dtos
+      - construct_symbol_dto
+      - construct_full_name_dto
       - construct_synonym_dtos
+      - construct_component_dtos
       - reference_curies
     slot_usage:
-      name:
+      construct_symbol_dto:
         required: true
 
   ConstructComponentSlotAnnotation:
     is_a: SlotAnnotation
     slots:
       - single_construct
+      - relation
       - component_symbol
       - related_notes
       - taxon
@@ -201,6 +204,12 @@ classes:
     slot_usage:
       single_construct:
         required: true
+      relation:
+        range: VocabularyTerm
+        notes: >-
+          The relation should be a VocabularyTerm with one of the following
+          values - expresses (RO:0002292) / is_regulated_by (RO:0002334) /
+          targets (RO:0002436). CV: 'Construct Genomic Entity Association Relation'
       component_symbol:
         required: true
       related_notes:
@@ -213,10 +222,37 @@ classes:
   ConstructComponentSlotAnnotationDTO:
     is_a: SlotAnnotationDTO
     slots:
+      - relation_name
       - component_symbol
       - note_dtos
       - taxon_curie
       - taxon_text
+
+  ConstructSymbolSlotAnnotation:
+    description: >-
+      The one current symbol for the construct.
+    is_a: NameSlotAnnotation
+    slots:
+      - single_construct
+    slot_usage:
+      single_construct:
+        required: true
+      name_type:
+        notes: >-
+          permissible_values: nomenclature_symbol (VocabularyTerm), systematic_name (VocabularyTerm)
+
+  ConstructFullNameSlotAnnotation:
+    description: >-
+      The one current full name for the construct.
+    is_a: NameSlotAnnotation
+    slots:
+      - single_construct
+    slot_usage:
+      single_construct:
+        required: true
+      name_type:
+        notes: >-
+          permissible_values: full_name (VocabularyTerm)
 
   ConstructSynonymSlotAnnotation:
     description: >-
@@ -359,14 +395,49 @@ slots:
     range: string
     required: true
 
+  construct_symbol:
+    description: >-
+      Holds between a Construct and the one current accepted symbol
+    exact_mappings:
+      - biolink:symbol
+    domain: Construct
+    range: ConstructSymbolSlotAnnotation
+    required: true
+    multivalued: false
+
+  construct_symbol_dto:
+    description: >-
+      Holds between a Construct and the one current accepted symbol
+    domain: ConstructDTO
+    range: SymbolSlotAnnotationDTO
+    required: true
+    multivalued: false
+    inlined: true
+
+  construct_full_name:
+    description: Holds between a Construct and a full name.
+    domain: Construct
+    required: false
+    multivalued: false
+    range: ConstructFullNameSlotAnnotation
+
+  construct_full_name_dto:
+    description: Holds between a Construct and a full name.
+    domain: ConstructDTO
+    range: NameSlotAnnotationDTO
+    multivalued: false
+    required: false
+    inlined: true
+
   construct_synonyms:
-    description: Holds between an Construct and a synonym.
+    description: Holds between a Construct and a list of synonyms.
     domain: Construct
     required: false
     multivalued: true
     range: ConstructSynonymSlotAnnotation
 
   construct_synonym_dtos:
+    description: Holds between a Construct and a list of synonyms.
     domain: ConstructDTO
     range: NameSlotAnnotationDTO
     multivalued: true
@@ -428,7 +499,6 @@ slots:
     range: string
     
   single_construct:
-    domain: ConstructComponentSlotAnnotation
     range: Construct
     multivalued: false
 

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -50,6 +50,9 @@ classes:
       - unique_id
       - mod_entity_id
       - mod_internal_id
+      - synonyms
+      - secondary_identifiers
+      - cross_references
       - taxon
       - generated_by
       - manufactured_by
@@ -63,6 +66,9 @@ classes:
       - mod_entity_id
       - mod_internal_id
       - taxon_curie
+      - synonyms
+      - secondary_identifiers
+      - cross_reference_dtos
       - generated_by_identifier # needs to change: currently no common identifier field for Agent class
       - manufactured_by_identifier # needs to change: currently no common identifier field for Agent class
       - data_provider_dto
@@ -90,8 +96,6 @@ classes:
       - heavy_chain_isotype
       - light_chain_isotype
       - antibody_target_genes
-      - cross_references
-      - secondary_identifiers
       - references
       - original_reference
       - related_notes
@@ -137,8 +141,6 @@ classes:
       - heavy_chain_isotype_name
       - light_chain_isotype_name
       - antibody_target_gene_curies
-      - cross_reference_dtos
-      - secondary_identifiers
       - reference_curies
       - original_reference_curie
       - note_dtos

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -7,9 +7,6 @@
       "internal": false,
       "obsolete": false,
       "mod_entity_id": "WB:WBConstruct123",
-      "taxon_curie": "NCBITaxon:6239",
-      "generated_by_identifier": "WB:WBLaboratory123",
-      "manufactured_by_identifier": "Construct Corps",
       "construct_symbol_dto": {
         "name_type_name": "nomenclature_symbol",
         "format_text": "const123",
@@ -48,18 +45,6 @@
       "secondary_identifiers": [
         "AB:12345",
         "ZY:4321"
-      ],
-      "cross_reference_dtos": [
-        {"referenced_curie": "CD:54321",
-          "prefix": "CD",
-          "page_area": "construct",
-          "display_name": "CD Construct 54321",
-          "internal": false},
-        {"referenced_curie": "EF:98765",
-          "prefix": "EF",
-          "page_area": "construct",
-          "display_name": "EF Construct 98765",
-          "internal": false}
       ],
       "reference_curies": [
         "PMID:101231321"

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -1,5 +1,5 @@
 {
-  "linkml_version": "1.8.0",
+  "linkml_version": "1.9.0",
   "construct_ingest_set": [
     {
       "created_by_curie": "WB:WBPerson123",
@@ -7,10 +7,31 @@
       "internal": false,
       "obsolete": false,
       "mod_entity_id": "WB:WBConstruct123",
-      "name": "Construct A",
       "taxon_curie": "NCBITaxon:6239",
       "generated_by_identifier": "WB:WBLaboratory123",
       "manufactured_by_identifier": "Construct Corps",
+      "construct_symbol_dto": {
+        "name_type_name": "nomenclature_symbol",
+        "format_text": "const123",
+        "display_text": "const123",
+        "synonym_url": "https://synonym_url.com/const123",
+        "synonym_scope_name": "exact",
+        "evidence_curies": [
+          "PMID:01231002"
+        ],
+        "internal": false
+      },
+      "construct_full_name_dto": {
+        "name_type_name": "full_name",
+        "format_text": "Construct A",
+        "display_text": "Construct A",
+        "synonym_url": "https://synonym_url.com/a83",
+        "synonym_scope_name": "exact",
+        "evidence_curies": [
+          "PMID:01231002"
+        ],
+        "internal": false
+      },
       "construct_synonym_dtos": [
         {
           "name_type_name": "synonym",
@@ -45,6 +66,7 @@
       ],
       "construct_component_dtos": [
         {
+          "relation_name": "expresses",
           "component_symbol": "comA",
           "taxon_curie": "NCBITaxon:6239",
           "taxon_text": "Caenorhabditis elegans",

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -11,6 +11,26 @@
       "taxon_curie": "NCBITaxon:6239",
       "generated_by_identifier": "WB:WBLaboratory123",
       "manufactured_by_identifier": "Construct Corps",
+      "synonyms": [
+        "construct synonym 1",
+        "construct synonym 2"
+      ],
+      "secondary_identifiers": [
+        "AB:12345",
+        "ZY:4321"
+      ],
+      "cross_reference_dtos": [
+        {"referenced_curie": "CD:54321",
+          "prefix": "CD",
+          "page_area": "construct",
+          "display_name": "CD Construct 54321",
+          "internal": false},
+        {"referenced_curie": "EF:98765",
+          "prefix": "EF",
+          "page_area": "construct",
+          "display_name": "EF Construct 98765",
+          "internal": false}
+      ],
       "reference_curies": [
         "PMID:101231321"
       ],

--- a/test/data/construct_test.json
+++ b/test/data/construct_test.json
@@ -11,9 +11,18 @@
       "taxon_curie": "NCBITaxon:6239",
       "generated_by_identifier": "WB:WBLaboratory123",
       "manufactured_by_identifier": "Construct Corps",
-      "synonyms": [
-        "construct synonym 1",
-        "construct synonym 2"
+      "construct_synonym_dtos": [
+        {
+          "name_type_name": "synonym",
+          "format_text": "Construct Alpha",
+          "display_text": "Construct α",
+          "synonym_url": "https://synonym_url.com/ConstructAlpha",
+          "synonym_scope_name": "exact",
+          "evidence_curies": [
+            "PMID:01231002"
+          ],
+          "internal": false
+        }
       ],
       "secondary_identifiers": [
         "AB:12345",


### PR DESCRIPTION
The Construct class needs synonyms, secondary IDs and cross references. These have now been added to the Reagent and ReagentDTO superclasses to accommodate the Construct and Antibody classes (FlyBase currently submits these properties for Construct submissions to the FMS).