### PR TITLE
reformat GeneChangeEventSlotAnnotation description

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -10440,7 +10440,7 @@
                     "type": "array"
                 },
                 "related_notes": {
-                    "description": "Valid note types are available for viewing in the A-Team curation tool Controlled Vocabulary Terms Table (in the \"Gene note types\" vocabulary) on the production environment (curation.alliancegenome.org). New terms can be added as needed.",
+                    "description": "Valid note types are available for viewing in the A-Team curation tool Controlled Vocabulary Terms Table (in the Gene note types vocabulary) on the production environment (curation.alliancegenome.org). New terms can be added as needed.",
                     "items": {
                         "$ref": "#/$defs/Note"
                     },
@@ -10485,7 +10485,7 @@
         },
         "GeneChangeEventSlotAnnotation": {
             "additionalProperties": false,
-            "description": "A major change to an entity: e.g., new, merge, split, rename, deprecation. Proposed event_type vocabulary:\n  new: The entity was created (excluding new entities from split/merges).\n  merge: The entity subsumed other entities in a merge; objects subsumed\n         in the merge get \"deprecation\" type ChangeEvent annotations.\n  split: The entity was split from another entity; objects deprecated in\n         the split get \"deprecation\" type ChangeEvent annotations.\n  deprecation: The entity was made obsolete. This may include objects\n               deprecated by some merge/split event.\n  rename: A current accepted name of the entity was changed.\n  type_change: The entity type was changed.\nProposed status vocabulary:\n  provisional:\n  approved:",
+            "description": "A major change to an entity: e.g., new, merge, split, rename, deprecation. Proposed event_type vocabulary below. new - The entity was created (excluding new entities from split/merges). merge - The entity subsumed other entities in a merge; objects subsumed in the merge get deprecation type ChangeEvent annotations. split - The entity was split from another entity; objects deprecated in the split get deprecation type ChangeEvent annotations. deprecation - The entity was made obsolete. This may include objects deprecated by some merge/split event. rename - A current accepted name of the entity was changed. type_change - The entity type was changed. Proposed status vocabulary: provisional/approved.",
             "properties": {
                 "acquires_in_merge": {
                     "description": "For an entity that persists through a merge, the list of entities that it subsumes in a given NomenclatureEvent.",

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -80,7 +80,7 @@ classes:
       related_notes:
         description: >-
           Valid note types are available for viewing in the A-Team curation tool
-          Controlled Vocabulary Terms Table (in the "Gene note types" vocabulary)
+          Controlled Vocabulary Terms Table (in the Gene note types vocabulary)
           on the production environment (curation.alliancegenome.org). New terms
           can be added as needed.
 
@@ -157,19 +157,17 @@ classes:
     aliases: ['ChangeEvent', 'EventHistoryEntry', 'NomenclatureEvent']
     description: >-
       A major change to an entity: e.g., new, merge, split, rename, deprecation.
-      Proposed event_type vocabulary:
-        new: The entity was created (excluding new entities from split/merges).
-        merge: The entity subsumed other entities in a merge; objects subsumed
-               in the merge get "deprecation" type ChangeEvent annotations.
-        split: The entity was split from another entity; objects deprecated in
-               the split get "deprecation" type ChangeEvent annotations.
-        deprecation: The entity was made obsolete. This may include objects
-                     deprecated by some merge/split event.
-        rename: A current accepted name of the entity was changed.
-        type_change: The entity type was changed.
-      Proposed status vocabulary:
-        provisional:
-        approved:
+      Proposed event_type vocabulary below.
+      new - The entity was created (excluding new entities from split/merges).
+      merge - The entity subsumed other entities in a merge; objects subsumed
+      in the merge get deprecation type ChangeEvent annotations.
+      split - The entity was split from another entity; objects deprecated in
+      the split get deprecation type ChangeEvent annotations.
+      deprecation - The entity was made obsolete. This may include objects
+      deprecated by some merge/split event.
+      rename - A current accepted name of the entity was changed.
+      type_change - The entity type was changed.
+      Proposed status vocabulary: provisional/approved.
     slots:
       - single_gene
       - event_type


### PR DESCRIPTION
Updated formatting of the `GeneChangeEventSlotAnnotation` description in an attempt to fix the display issues in the LinkML model browser.