### PR TITLE
align with FMS submission: add gene_synopsis, make gene_type required

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -10837,6 +10837,12 @@
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
                 },
+                "note_dtos": {
+                    "items": {
+                        "$ref": "#/$defs/NoteDTO"
+                    },
+                    "type": "array"
+                },
                 "obsolete": {
                     "description": "Entity is no longer current.",
                     "type": "boolean"

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -10410,6 +10410,10 @@
                     },
                     "type": "array"
                 },
+                "gene_synopsis": {
+                    "description": "Human readable gene description or synopsis.",
+                    "type": "string"
+                },
                 "gene_systematic_name": {
                     "$ref": "#/$defs/GeneSystematicNameSlotAnnotation",
                     "description": "The one current systematic name for a gene: e.g., YHR084W, R09F10.2."
@@ -10482,6 +10486,7 @@
             },
             "required": [
                 "gene_symbol",
+                "gene_type",
                 "curie",
                 "taxon",
                 "data_provider",
@@ -10824,6 +10829,10 @@
                     },
                     "type": "array"
                 },
+                "gene_synopsis": {
+                    "description": "Human readable gene description or synopsis.",
+                    "type": "string"
+                },
                 "gene_systematic_name_dto": {
                     "$ref": "#/$defs/SystematicNameSlotAnnotationDTO",
                     "description": "The one current systematic name for a gene: e.g., YHR084W, R09F10.2."
@@ -10851,6 +10860,7 @@
             },
             "required": [
                 "gene_symbol_dto",
+                "gene_type_curie",
                 "curie",
                 "taxon_curie",
                 "data_provider_dto",

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -10410,10 +10410,6 @@
                     },
                     "type": "array"
                 },
-                "gene_synopsis": {
-                    "description": "Human readable gene description or synopsis.",
-                    "type": "string"
-                },
                 "gene_systematic_name": {
                     "$ref": "#/$defs/GeneSystematicNameSlotAnnotation",
                     "description": "The one current systematic name for a gene: e.g., YHR084W, R09F10.2."
@@ -10828,10 +10824,6 @@
                         "$ref": "#/$defs/NameSlotAnnotationDTO"
                     },
                     "type": "array"
-                },
-                "gene_synopsis": {
-                    "description": "Human readable gene description or synopsis.",
-                    "type": "string"
                 },
                 "gene_systematic_name_dto": {
                     "$ref": "#/$defs/SystematicNameSlotAnnotationDTO",

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -99,6 +99,7 @@ classes:
       - gene_synonym_dtos
       - gene_secondary_id_dtos
       - gene_type_curie
+      - note_dtos
 
   GeneSymbolSlotAnnotation:
     description: >-

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -55,6 +55,7 @@ classes:
       - gene_systematic_name
       - gene_synonyms
       - gene_secondary_ids
+      - gene_synopsis
       - related_notes
       - gene_type
       - gene_types_secondary
@@ -94,6 +95,7 @@ classes:
       - gene_synonym_dtos
       - gene_secondary_id_dtos
       - gene_type_curie
+      - gene_synopsis
 
   GeneSymbolSlotAnnotation:
     description: >-
@@ -260,6 +262,18 @@ slots:
     inlined: true
     inlined_as_list: true
 
+  gene_synopsis:
+    description: >-
+      Human readable gene description or synopsis.
+    notes: >-
+      Represents agr_schemas gene.json geneSynopsis attribute.
+      I chose not to import the related geneSynopsisUrl as this attribute is not
+      currently being used as directed by anyone.
+    domain: Gene
+    range: string
+    required: false
+    multivalued: false
+
   gene_systematic_name:
     description: >-
       The one current systematic name for a gene: e.g., YHR084W, R09F10.2.
@@ -299,11 +313,15 @@ slots:
     description: SOTerm describing gene type
     domain: Gene
     range: SOTerm
+    required: true
+    multivalued: false
 
   gene_type_curie:
     description: Curie of SOTerm describing gene type
     domain: GeneDTO
     range: string
+    required: true
+    multivalued: false
 
   gene_types_secondary:
     description: >-

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -48,6 +48,11 @@ classes:
       here can mean one that is directly responsible for the gene's function (e.g. catalysis,
       structure, etc.) or one that is translated to produce a functional polypeptide/protein.
       A pseudogene may be considered a gene under this definition, albeit no longer functional.
+    notes: >-
+      Submit FMS BGI geneSynopsis in the related_notes slot as a Note of type
+      MOD_provided_gene_description.
+      There is no LinkML slot corresponding to the BGI geneSynopsisUrl as this
+      attribute was not being used by any MODs (at least as directed).
     is_a: GenomicEntity
     slots:
       - gene_symbol
@@ -55,7 +60,6 @@ classes:
       - gene_systematic_name
       - gene_synonyms
       - gene_secondary_ids
-      - gene_synopsis
       - related_notes
       - gene_type
       - gene_types_secondary
@@ -95,7 +99,6 @@ classes:
       - gene_synonym_dtos
       - gene_secondary_id_dtos
       - gene_type_curie
-      - gene_synopsis
 
   GeneSymbolSlotAnnotation:
     description: >-
@@ -261,18 +264,6 @@ slots:
     multivalued: true
     inlined: true
     inlined_as_list: true
-
-  gene_synopsis:
-    description: >-
-      Human readable gene description or synopsis.
-    notes: >-
-      Represents agr_schemas gene.json geneSynopsis attribute.
-      I chose not to import the related geneSynopsisUrl as this attribute is not
-      currently being used as directed by anyone.
-    domain: Gene
-    range: string
-    required: false
-    multivalued: false
 
   gene_systematic_name:
     description: >-


### PR DESCRIPTION
Simple changes to bring LinkML model in line with agr_schemas model.
1. Add gene_synopsis slot (a simple string).
2. Make gene_type/gene_type_curie (aka soTermId, gene biotype) a required slot for Gene/GeneDTO classes

I want to handle gene genomic locations in a separate PR.