### PR TITLE
Base-table-specific subject and object slots

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -16895,6 +16895,10 @@
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
                 },
+                "object_ontology_term": {
+                    "description": "connects an association to the object of the association when the object is a child of OntologyTerm. For example, in a gene disease annotation, a DOTerm is the object describing the disease.",
+                    "type": "string"
+                },
                 "obsolete": {
                     "description": "Entity is no longer current.",
                     "type": "boolean"
@@ -16909,12 +16913,18 @@
                     },
                     "type": "array"
                 },
+                "subject_ontology_term": {
+                    "description": "connects an association to the subject of the association when the subject is a child of OntologyTerm.",
+                    "type": "string"
+                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": "string"
                 }
             },
             "required": [
+                "subject_ontology_term",
+                "object_ontology_term",
                 "relation",
                 "internal"
             ],

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -178,18 +178,21 @@ classes:
       mod_entity_id:
         required: true
 
-  SequenceTargetingReagentToGeneAssociation:
+  SequenceTargetingReagentGeneAssociation:
     description: >-
       the relationship between a Sequence Targeting Reagent and its targeted
       genes. The relation should be a VocabularyTerm with one of the following
       values - targets
     is_a: EvidenceAssociation
+    slots:
+      - subject_biological_entity
+      - object_biological_entity
     slot_usage:
       relation:
         range: VocabularyTerm
-      subject:
+      subject_biological_entity:
         range: SequenceTargetingReagent
-      object:
+      object_biological_entity:
         range: Gene
 
   # TO DO: create SequenceTargetingReagentToGeneAssociationDTO class? [CG]
@@ -408,12 +411,15 @@ classes:
       The relationship between an allele and a cell line.  Includes mutant/
       embryonic stem cell lines known to carry the allele, and parental cell
       line of alleles made in embryonic stem cells.
+    slots:
+      - subject_biological_entity
+      - object_biological_entity
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Allele
       relation:
         range: VocabularyTerm
-      object:
+      object_biological_entity:
         range: CellLine
 
   AlleleCellLineAssociationDTO:
@@ -428,23 +434,22 @@ classes:
         - cell_line_identifier
 
   AlleleConstructAssociation:
-    is_a: AlleleGenomicEntityAssociation
+    is_a: AlleleReagentAssociation
     description: >-
       The relationship between an allele and constructs contained in
       that allele.
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Allele
       relation:
-        range: VocabularyTerm
         notes: >-
           CV 'Allele Construct Association Relation' including - contains, contains_coinjection_marker,
           contains_phenotypic_sequence_feature, and contains_innocuous_sequence_feature
-      object:
+      object_reagent:
         range: Construct
 
   AlleleConstructAssociationDTO:
-    is_a: AlleleGenomicEntityAssociationDTO
+    is_a: AlleleReagentAssociationDTO
     description: >-
       The relationship between an allele and constructs contained in
       that allele.
@@ -474,16 +479,16 @@ classes:
   AlleleGenerationMethodAssociation:
     is_a: EvidenceAssociation
     slots:
+      - subject_biological_entity
+      - object_generation_method 
       - mutation_target_strain
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Allele
       relation:
         any_of:
           equals_string: has_generation_method
         notes: CV 'Allele Generation Method Association Relation'
-      object:
-        range: GenerationMethod
 
   AlleleGenerationMethodAssociationDTO:
     is_a: EvidenceAssociationDTO
@@ -504,14 +509,16 @@ classes:
     description: >-
       Association between an allele and a genomic entity
     slots:
+      - subject_biological_entity
+      - object_biological_entity
       - evidence_code
       - related_note
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Allele
       relation:
         range: VocabularyTerm # If we can adequately represent all needed relations in RO, this could be ROTerm
-      object:
+      object_biological_entity:
         range: GenomicEntity
       evidence:
         required: false # This needs to be not required, at least in the base class
@@ -530,14 +537,14 @@ classes:
     description: >-
       The relationship between an allele and an image.
     slots:
+      - subject_biological_entity
+      - object_image
       - primary_image
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Allele
       relation:
         range: VocabularyTerm
-      object:
-        range: Image
       primary_image:
         description: >-
           Can be null; if false, maybe you would show all the images.
@@ -562,10 +569,13 @@ classes:
     is_a: EvidenceAssociation
     description: >-
       The relationship between an allele and the origin of the allele.
+    slots:
+      - subject_biological_entity
+      - object_biological_entity
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Allele
-      object:
+      object_biological_entity:
         range: AffectedGenomicModel
 
   AlleleOriginAssociationDTO:
@@ -582,7 +592,7 @@ classes:
     description: >-
       Association between an allele and a protein
     slot_usage:
-      object:
+      object_biological_entity:
         range: Protein
 
   AlleleProteinAssociationDTO:
@@ -592,12 +602,41 @@ classes:
     slots:
       - protein_identifier
 
+  AlleleReagentAssociation:
+    is_a: EvidenceAssociation
+    abstract: true
+    description: >-
+      Association between an allele and a genomic entity
+    slots:
+      - subject_biological_entity
+      - object_reagent
+      - evidence_code
+      - related_note
+    slot_usage:
+      subject_biological_entity:
+        range: Allele
+      relation:
+        range: VocabularyTerm
+      object_reagent:
+        range: Reagent
+      evidence:
+        required: false # This needs to be not required, at least in the base class
+
+  AlleleReagentAssociationDTO:
+    is_a: EvidenceAssociationDTO
+    abstract: true
+    slots:
+      - allele_identifier
+      - relation_name
+      - evidence_code_curie
+      - note_dto
+      
   AlleleTranscriptAssociation:
     is_a: AlleleGenomicEntityAssociation
     description: >-
       Association between an allele and a transcript
     slot_usage:
-      object:
+      object_biological_entity:
         range: Transcript
 
   AlleleTranscriptAssociationDTO:
@@ -614,9 +653,7 @@ classes:
       Allele may have many variants and a variant can be present in many
       alleles.
     slot_usage:
-      subject:
-        range: Allele
-      object:
+      object_biological_entity:
         range: Variant
 
   AlleleVariantAssociationDTO:
@@ -1071,6 +1108,22 @@ slots:
     domain: AlleleAlleleAssociationDTO
     range: string
 
+  object_generation_method:
+    is_a: association_slot
+    description: >-
+      connects an association to the object of the association when the object is a GenerationMethod.
+      For example, the generation method in a allele-to-generation method association.
+    required: true
+    range: GenerationMethod
+
+  object_image:
+    is_a: association_slot
+    description: >-
+      connects an association to the object of the association when the object is a GenerationMethod.
+      For example, the generation method in a allele-to-generation method association.
+    required: true
+    range: Image
+    
   primary_image:
     description: >-
       The primary image for an allele that is used to represent the allele on a page.

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -318,29 +318,24 @@ classes:
 
   Association:
     is_a: AuditedObject
+    abstract: true
     description: >-
-      A typed association between two entities, supported by evidence.  Associations have three base slots: subject,
+      A typed association between two entities, supported by evidence.  Associations are comprised of: subject,
       object, and relation, but they can have any number of additional attributes that help qualify the relationship
       between the subject and the object.  The subject is the curie (or identifier) of the class that is the subject
       of the association, and likewise the object is the curie (or identifier of the class that is the object. The
       relationship between subject and object is defined by the relation slot (which can also be constrained
-      using the range of the relation).
-    exact_mappings:
-      - biolink:association
+      using the range of the relation).  The subject and object slots are defined in child classes with slot name
+      suffixes relating to the type of entity (this is to avoid a limitation in the Hibernate implementation which
+      prevents defining generic subject and object slots)
     notes:
       Keeping this more generic than biolink:association by foregoing the
       qualifiers and negated slots.
     slots:
-      - subject
       - relation
-      - object
     slot_usage:
-        subject:
-            required: true
-        relation:
-            required: true
-        object:
-            required: true
+      relation:
+        required: true
 
   SingleReferenceAssociation:
     abstract: true
@@ -1196,28 +1191,63 @@ slots:
     domain: CrossReference
     range: ResourceDescriptorPage
 
-  ## --------------------
+## --------------------
 ## ASSOCIATION SLOTS
 ## --------------------
-
-  subject:
-    is_a: association_slot
-    description: >-
-      connects an association to the subject of the association.
-      For example, in a gene-to-phenotype association, the gene is subject and phenotype is object.
-    required: true
-    exact_mappings:
-      - owl:annotatedSource
-      - biolink:subject
 
   object:
     is_a: association_slot
     description: >-
-      connects an association to the object of the association.
-      For example, in a gene-to-phenotype association, the gene is subject and phenotype is object.
+      connects an association to the object of the association when the object is represented by a string
     required: true
-    exact_mappings:
-      - biolink:object
+    range: string
+
+  subject_association:
+    is_a: association_slot
+    description: >-
+      describes the subject of an association when the subject is an association itself
+    required: true
+    range: Association
+
+  subject_biological_entity:
+    is_a: association_slot
+    description: >-
+      connects an association to the subject of the association when the subject is a child of BiologicalEntity.
+      For example, the gene in a gene-to-phenotype association.
+    required: true
+    range: BiologicalEntity
+
+  object_biological_entity:
+    is_a: association_slot
+    description: >-
+      connects an association to the object of the association when the object is a child of BiologicalEntity.
+      For example, the gene in an allele-to-gene association.
+    required: true
+    range: BiologicalEntity
+
+  subject_reagent:
+    is_a: association_slot
+    description: >-
+      connects an association to the subject of the association when the subject is a child of Reagent.
+      For example, the construct in a construct-to-genomic entity association.
+    required: true
+    range: Reagent
+
+  object_reagent:
+    is_a: association_slot
+    description: >-
+      connects an association to the object of the association when the object is a child of Reagent.
+      For example, the construct in a allele-to-construct association.
+    required: true
+    range: Reagent
+
+  object_ontology_term:
+    is_a: association_slot
+    description: >-
+      connects an association to the object of the association when the object is a child of OntologyTerm.
+      For example, in a gene disease annotation, a DOTerm is the object describing the disease.
+    required: true
+    range: OntologyTerm
 
   relation:
     is_a: association_slot

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -1241,6 +1241,13 @@ slots:
     required: true
     range: Reagent
 
+  subject_ontology_term:
+    is_a: association_slot
+    description: >-
+      connects an association to the subject of the association when the subject is a child of OntologyTerm.
+    required: true
+    range: OntologyTerm
+    
   object_ontology_term:
     is_a: association_slot
     description: >-

--- a/model/schema/expression.yaml
+++ b/model/schema/expression.yaml
@@ -137,11 +137,9 @@ classes:
       This aims to provide the same functionality as MGI imagepane.
       Some MODs (like ZFIN) point to the whole image. In these cases,
       the pane would encompass the whole image.
-    slot_usage:
-      subject:
-        range: ExpressionAnnotation
-      object:
-        range: ImagePane
+    slots:
+      - subject_expression_annotation
+      - object_image_pane
 
   # GeneExpressionStatement:
   #   is_a: EntityStatement     # Update to use Note class instead?
@@ -264,6 +262,13 @@ slots:
       The image associated with the object.
     range: Image
 
+  object_image_pane:
+    is_a: association_slot
+    description: >-
+      connects an association to the object of the association when the object is an ImagePane
+    required: true
+    range: ImagePane
+
   spatial_qualifiers:
     description: >-
       Qualifiers that describe the spatial characteristics of an event.
@@ -286,6 +291,13 @@ slots:
     domain: ExpressionExperiment
     range: Allele
     multivalued: true
+
+  subject_expression_annotation:
+    is_a: association_slot
+    description: >-
+      connects an association to the subject of the association when the subject is an expression annotatoin.
+    required: true
+    range: ExpressionAnnotation
 
   temporal_qualifiers:
     description: >-

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -209,11 +209,13 @@ classes:
     description: >-
       Location(s) of the gene on the genome.
     slots:
+      - subject_biological_entity
+      - object_biological_entity
       - strand
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Gene
-      object:
+      object_biological_entity:
         range: AssemblyComponent
       evidence:
         notes: List all references that support a given location association.
@@ -238,12 +240,14 @@ classes:
       How do we handle location to specific chromosome arms? Different asso'n,
       or different slot here, etc?
     slots:
+      - subject_biological_entity
+      - object_biological_entity
       - left_boundary_marker
       - right_boundary_marker
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Gene
-      object:
+      object_biological_entity:
         range: Chromosome
       relation:
         any_of:
@@ -259,17 +263,19 @@ classes:
       Should this be limited to reports of specific cM on a given chromosome,
       or should it include genetic segregation studies that link gene to a
       chromosome?
+    slots:
+      - subject_biological_entity
+      - object_biological_entity
+      - genetic_map_position_centimorgan
+      - genetic_map_position_centimorgan_error
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Gene
-      object:
+      object_biological_entity:
         range: Chromosome
       relation:
         any_of:
           - equals_string: has_location
-    slots:
-      - genetic_map_position_centimorgan
-      - genetic_map_position_centimorgan_error
 
 ## ------------
 ## SLOTS

--- a/model/schema/geneInteraction.yaml
+++ b/model/schema/geneInteraction.yaml
@@ -56,17 +56,20 @@ classes:
       to gene product relationships. Includes homology and interaction.
     abstract: true
     is_a: EvidenceAssociation
+    slots:
+      - subject_biological_entity
+      - object_biological_entity
     defining_slots:
-      - subject
-      - object
+      - subject_biological_entity
+      - object_biological_entity
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Gene
         description: >-
           the subject gene in the association. If the relation is symmetric,
           subject vs object is arbitrary. We allow a gene product to stand
           as a proxy for the gene or vice versa.
-      object:
+      object_biological_entity:
         range: Gene
         description: >-
           the object gene in the association. If the relation is symmetric,

--- a/model/schema/ontologyTerm.yaml
+++ b/model/schema/ontologyTerm.yaml
@@ -165,13 +165,11 @@ classes:
   OntologyTermClosure:
     is_a: EvidenceAssociation
     slots:
+      - subject_ontology_term
+      - object_ontology_term
       - relationship_type
       - distance_between
     slot_usage:
-      subject:
-        range: OntologyTerm
-      object:
-        range: OntologyTerm
       distance_between:
         description: >-
           distance_between is zero for reflexive–transitive closure

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -91,9 +91,11 @@ classes:
     description: >-
       An annotation asserting an association between a biological entity and a phenotype supported by evidence.
     slots:
+      - subject_biological_entity
       - phenotype_term
+      - object
     slot_usage:
-      subject:                            # objectId in JSON schema
+      subject_biological_entity:                            # objectId in JSON schema
         description: >-
           The biological entity (e.g. gene, allele, genotype) to which the phenotype is associated, by direct curation.
         required: true
@@ -152,8 +154,7 @@ classes:
     slots:
       - sgd_strain_background   # Does this also apply to phenotype annotations?
     slot_usage:
-      subject:
-        required: true
+      subject_biological_entity:
         description: >-
           The gene to which the phenotype ontology term is associated.
         range: Gene
@@ -175,7 +176,7 @@ classes:
       - inferred_gene
       - asserted_genes
     slot_usage:
-      subject:
+      subject_biological_entity:
         description: >-
           The allele to which the phenotype ontology term is associated.
         range: Allele
@@ -209,7 +210,7 @@ classes:
       - asserted_genes
       - asserted_allele
     slot_usage:
-      subject:
+      subject_biological_entity:
         description: >-
           The AGM to which the phenotype ontology term is associated.
         range: AffectedGenomicModel
@@ -244,6 +245,8 @@ classes:
     description: >-
       An annotation asserting an association between a biological entity and a disease supported by evidence.
     slots:
+      - subject_biological_entity
+      - object_ontology_term
       - negated
       - evidence_codes
       - annotation_type
@@ -274,7 +277,7 @@ classes:
           The model organism database (MOD) internal identifier for the disease annotation. When available,
           this is used for determination of distinctness instead of the Unique ID field.
         required: false
-      subject:
+      subject_biological_entity:
         required: true
         description: >-
           The biological entity to which the disease ontology term is associated.
@@ -282,7 +285,7 @@ classes:
       negated:
         description: >-
           The negative qualifier for the annotation.
-      object:
+      object_ontology_term:
         required: true
         description: >-
           The disease ontology term.
@@ -349,7 +352,7 @@ classes:
     slots:
       - sgd_strain_background
     slot_usage:
-      subject:
+      subject_biological_entity:
         required: true
         description: >-
           The gene to which the disease ontology term is associated.
@@ -378,7 +381,7 @@ classes:
       - inferred_gene
       - asserted_genes
     slot_usage:
-      subject:
+      subject_biological_entity:
         description: >-
           The allele to which the disease ontology term is associated.
         range: Allele
@@ -417,7 +420,7 @@ classes:
       - asserted_genes
       - asserted_allele
     slot_usage:
-      subject:
+      subject_biological_entity:
         description: >-
           The AGM to which the disease ontology term is associated.
         range: AffectedGenomicModel

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -264,9 +264,11 @@ classes:
       a known genomic entity with a curie and any accompanying meta data about the
       relationship between the construct and that genomic entity component
     slots:
+      - subject_reagent
+      - object_biological_entity
       - related_notes
     slot_usage:
-      subject:
+      subject_reagent:
         range: Construct
       relation:
         range: VocabularyTerm
@@ -274,7 +276,7 @@ classes:
           The relation should be a VocabularyTerm with one of the following
           values - expresses (RO:0002292) / is_regulated_by (RO:0002334) /
           targets (RO:0002436). CV: 'Construct Genomic Entity Association Relation'
-      object:
+      object_biological_entity:
         range: GenomicEntity
       related_notes:
         required: false

--- a/model/schema/variantConsequence.yaml
+++ b/model/schema/variantConsequence.yaml
@@ -46,8 +46,8 @@ classes:
       consequences
     abstract: true
     slots:
-      - subject
-      - object
+      - subject_association
+      - object_biological_entity
       - vep_consequence
       - vep_impact
       - polyphen_score
@@ -61,9 +61,9 @@ classes:
       Class for gene-level VEP results
     is_a: VariantConsequence
     slot_usage:
-      object:
+      object_biological_entity:
         range: Gene
-      subject:
+      subject_association:
         range: VariantGenomicLocationAssociation
 
   VariantTranscriptConsequence:
@@ -85,9 +85,9 @@ classes:
       - hgvs_protein_nomenclature
       - hgvs_coding_nomenclature
     slot_usage:
-      object:
+      object_biological_entity:
         range: Transcript
-      subject:
+      subject_association:
         range: VariantTranscriptLocationAssociation
       amino_acid_reference:
         description: >-

--- a/model/schema/variation.yaml
+++ b/model/schema/variation.yaml
@@ -76,6 +76,8 @@ classes:
       the definition of the transcript or protein isoform used by the source has changed, or if there was an error
       in the source data.
     slots:
+      - subject_biological_entity
+      - object_biological_entity
       - hgvs
       - reference_sequence
       - variant_sequence
@@ -83,7 +85,7 @@ classes:
       - curated_consequence
       - sequence_of_reference_accession_number # Should this point to a chromosome object instead of a string? Will this be redundant with genomic location association of the subject?
     slot_usage:
-      subject:
+      subject_biological_entity:
         range: Variant
 
   VariantGenomicLocationAssociation:
@@ -103,7 +105,7 @@ classes:
       - dna_mutation_type
       - gene_localization_type
     slot_usage:
-      object:
+      object_biological_entity:
         description: >-
           The location reference object should be a chromosome assembly curie.
         range: AssemblyComponent
@@ -119,7 +121,7 @@ classes:
       - exon_number
       - intron_number
     slot_usage:
-      object:
+      object_biological_entity:
         description: >-
           Transcript associated with variant and for which a specific location and consequence of that variant
           is provided, as specified at source.  Multivalued=false for this slot because although a variant can have
@@ -140,7 +142,7 @@ classes:
       - number_amino_acids_removed
       - number_amino_acids_inserted
     slot_usage:
-      object:
+      object_biological_entity:
         description: >-
           Polypeptide associated with variant and for which a specific location and consequence of that variant is
           provided, as specified by curator. Multivalued=false for this slot because although a variant can have


### PR DESCRIPTION
@chris-grove @oblodgett
One of the reasons for the LinkML v2.0.0 migration was because Hibernate couldn't deal with Association subject/object slots with ranges belonging to different base tables in the database (e.g. one subject being a Gene with base table BiologicalEntity, and another being Construct with a base table Reagent).

The initially proposed solution was to have a single base table (AuditedObject) so that anything could be used for any slot.  When I implemented this we ran into the problem (that we can't currently get around) of the Hibernate indexing queries resulting in a number of columns that exceeds the Postgres limit.

The current PR in the agr_curation repo avoids this issue by making CurieObject the base table.  This allows OntologyTerms, Reagents, and BiologicalEntities to be used in the subject/object fields - this covers all our currently implemented associations but not all of the associations in the LinkML model.  Also, having implemented this in Java, it makes database queries, loading and indexing significantly slower.  The speed issue might be something we can improve, but that still leaves us with associations in the LinkML model that cannot be implemented as the model stands.

Given all of the above, I think we need to have separate subject and object slots for each base table in the database (this PR).  This is how we are currently working around the issue in the curation system, with a departure from the LinkML model version that we are reporting that we support.  I don't love the duplication, but I think that is something we have to live with.  I also don't like the fact that you need to know the base table in the database to determine the appropriate slot (e.g. when a Construct is the subject of an association, you need to know that the corresponding base table in our DB is the reagent table and therefore the slot required is subject_reagent).  For that reason, I'm inclined to think that maybe we should go even further with the separation/duplication than in this PR and have class-specific subject and object slots (e.g. subject_gene, subject_allele, etc.), although that would make life a bit harder when we want different things in the same column (e.g. for disease annotation subject).

Any thoughts?