### PR TITLE
Refactor association slots using domain prefix

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -12331,6 +12331,75 @@
             "title": "GeneFullNameSlotAnnotation",
             "type": "object"
         },
+        "GeneGeneAssociationDTO": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "created_by_curie": {
+                    "description": "Curie of the Person object representing the individual that created the entity",
+                    "type": "string"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "evidence_curies": {
+                    "description": "Curies of InformationContentEntity objects given as evidence",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "gene_relation_name": {
+                    "description": "Name of VocabularyTerm describing relationship between a subject entity and an object Gene",
+                    "type": "string"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "object_gene_identifier": {
+                    "description": "Identifier (curie/mod_entity_id/mod_internal_id) of the object gene in a gene-to-gene association",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": "boolean"
+                },
+                "subject_gene_identifier": {
+                    "description": "Identifier (curie/mod_entity_id/mod_internal_id) of the subject gene in a gene-to-gene association",
+                    "type": "string"
+                },
+                "updated_by_curie": {
+                    "description": "Curie of the Person object representing the individual that updated the entity",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "subject_gene_identifier",
+                "gene_relation_name",
+                "object_gene_identifier",
+                "internal"
+            ],
+            "title": "GeneGeneAssociationDTO",
+            "type": "object"
+        },
         "GeneGeneticInteraction": {
             "additionalProperties": false,
             "description": "A genetic interaction between genes (e.g. phenotypic suppression)",
@@ -12376,6 +12445,10 @@
                         "$ref": "#/$defs/InformationContentEntity"
                     },
                     "type": "array"
+                },
+                "gene_association_subject": {
+                    "$ref": "#/$defs/Gene",
+                    "description": "the subject gene in the association. If the relation is symmetric, subject vs object is arbitrary. We allow a gene product to stand as a proxy for the gene or vice versa."
                 },
                 "gene_gene_association_object": {
                     "$ref": "#/$defs/Gene",
@@ -12445,6 +12518,7 @@
                 "interaction_type",
                 "interactor_A_type",
                 "interactor_B_type",
+                "gene_association_subject",
                 "gene_gene_association_object",
                 "relation",
                 "internal"
@@ -12797,6 +12871,10 @@
                     },
                     "type": "array"
                 },
+                "gene_association_subject": {
+                    "$ref": "#/$defs/Gene",
+                    "description": "the subject gene in the association. If the relation is symmetric, subject vs object is arbitrary. We allow a gene product to stand as a proxy for the gene or vice versa."
+                },
                 "gene_gene_association_object": {
                     "$ref": "#/$defs/Gene",
                     "description": "the object gene in the association. If the relation is symmetric, subject vs object is arbitrary. We allow a gene product to stand as a proxy for the gene or vice versa."
@@ -12853,6 +12931,7 @@
                 "interaction_type",
                 "interactor_A_type",
                 "interactor_B_type",
+                "gene_association_subject",
                 "gene_gene_association_object",
                 "relation",
                 "internal"
@@ -13635,75 +13714,6 @@
                 "internal"
             ],
             "title": "GeneSystematicNameSlotAnnotation",
-            "type": "object"
-        },
-        "GeneToGeneAssociationDTO": {
-            "additionalProperties": false,
-            "description": "",
-            "properties": {
-                "created_by_curie": {
-                    "description": "Curie of the Person object representing the individual that created the entity",
-                    "type": "string"
-                },
-                "date_created": {
-                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "date_updated": {
-                    "description": "Date on which an entity was last modified.",
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "db_date_created": {
-                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "db_date_updated": {
-                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "evidence_curies": {
-                    "description": "Curies of InformationContentEntity objects given as evidence",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "gene_relation_name": {
-                    "description": "Name of VocabularyTerm describing relationship between a subject entity and an object Gene",
-                    "type": "string"
-                },
-                "internal": {
-                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
-                    "type": "boolean"
-                },
-                "object_gene_identifier": {
-                    "description": "Identifier (curie/mod_entity_id/mod_internal_id) of the object gene in a gene-to-gene association",
-                    "type": "string"
-                },
-                "obsolete": {
-                    "description": "Entity is no longer current.",
-                    "type": "boolean"
-                },
-                "subject_gene_identifier": {
-                    "description": "Identifier (curie/mod_entity_id/mod_internal_id) of the subject gene in a gene-to-gene association",
-                    "type": "string"
-                },
-                "updated_by_curie": {
-                    "description": "Curie of the Person object representing the individual that updated the entity",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "subject_gene_identifier",
-                "gene_relation_name",
-                "object_gene_identifier",
-                "internal"
-            ],
-            "title": "GeneToGeneAssociationDTO",
             "type": "object"
         },
         "GeneToGeneOrthology": {

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -178,19 +178,28 @@ classes:
       mod_entity_id:
         required: true
 
-  SequenceTargetingReagentToGeneAssociation:
+  SequenceTargetingReagentAssociation:
+    is_a: EvidenceAssociation
+    abstract: true
+    description: Base class for STR associations
+    attributes:
+      sequence_targeting_reagent_association_subject:
+        range: SequenceTargetingReagent
+        required: true
+
+  SequenceTargetingReagentGeneAssociation:
     description: >-
       the relationship between a Sequence Targeting Reagent and its targeted
       genes. The relation should be a VocabularyTerm with one of the following
       values - targets
-    is_a: EvidenceAssociation
+    is_a: SequenceTargetingReagentAssociation
+    attributes:
+      sequence_targeting_reagent_gene_association_object:
+        range: Gene
+        required: true
     slot_usage:
       relation:
         range: VocabularyTerm
-      subject:
-        range: SequenceTargetingReagent
-      object:
-        range: Gene
 
   # TO DO: create SequenceTargetingReagentToGeneAssociationDTO class? [CG]
 
@@ -384,15 +393,26 @@ classes:
   ## ALLELE ASSOCIATION CLASSES
   ## ------------
 
+  AlleleAssociation:
+    is_a: EvidenceAssociation
+    abstract: true
+    description: Base class for all Allele Associations
+    attributes:
+      allele_association_subject:
+        range: Allele
+        required: true
+  
   AlleleAlleleAssociation:
     is_a: AlleleGenomicEntityAssociation
     description: >-
       Association between an allele and another allele
+    attributes:
+      allele_allele_association_object:
+        range: Allele
+        required: true
     slot_usage:
       relation:
         notes: CV 'Allele Allele Association Relation'
-      object:
-        range: Allele
 
   AlleleAlleleAssociationDTO:
     is_a: AlleleGenomicEntityAssociationDTO
@@ -403,18 +423,18 @@ classes:
 
   # do mutant/parent/embryonic cell line associations need to be split out?
   AlleleCellLineAssociation:
-    is_a: EvidenceAssociation
+    is_a: AlleleAssociation
     description: >-
       The relationship between an allele and a cell line.  Includes mutant/
       embryonic stem cell lines known to carry the allele, and parental cell
       line of alleles made in embryonic stem cells.
+    attributes:
+      allele_cell_line_association_object:
+        range: CellLine
+        required: true
     slot_usage:
-      subject:
-        range: Allele
       relation:
         range: VocabularyTerm
-      object:
-        range: CellLine
 
   AlleleCellLineAssociationDTO:
       is_a: EvidenceAssociationDTO
@@ -432,16 +452,16 @@ classes:
     description: >-
       The relationship between an allele and constructs contained in
       that allele.
+    attributes:
+      allele_construct_association_object:
+        range: Construct
+        required: true
     slot_usage:
-      subject:
-        range: Allele
       relation:
         range: VocabularyTerm
         notes: >-
           CV 'Allele Construct Association Relation' including - contains, contains_coinjection_marker,
           contains_phenotypic_sequence_feature, and contains_innocuous_sequence_feature
-      object:
-        range: Construct
 
   AlleleConstructAssociationDTO:
     is_a: AlleleGenomicEntityAssociationDTO
@@ -460,9 +480,10 @@ classes:
     is_a: AlleleGenomicEntityAssociation
     description: >-
       Association between an allele and a gene
-    slot_usage:
-      object:
+    attributes:
+      allele_gene_association_object:
         range: Gene
+        required: true
 
   AlleleGeneAssociationDTO:
     description: >-
@@ -472,18 +493,18 @@ classes:
       - gene_identifier
 
   AlleleGenerationMethodAssociation:
-    is_a: EvidenceAssociation
+    is_a: AlleleAssociation
     slots:
       - mutation_target_strain
+    attributes:
+      allele_generation_method_association_object:
+        range: GenerationMethod
+        required: true
     slot_usage:
-      subject:
-        range: Allele
       relation:
         any_of:
           equals_string: has_generation_method
         notes: CV 'Allele Generation Method Association Relation'
-      object:
-        range: GenerationMethod
 
   AlleleGenerationMethodAssociationDTO:
     is_a: EvidenceAssociationDTO
@@ -499,7 +520,7 @@ classes:
           equals_string: has_generation_method
 
   AlleleGenomicEntityAssociation:
-    is_a: EvidenceAssociation
+    is_a: AlleleAssociation
     abstract: true
     description: >-
       Association between an allele and a genomic entity
@@ -507,12 +528,8 @@ classes:
       - evidence_code
       - related_note
     slot_usage:
-      subject:
-        range: Allele
       relation:
         range: VocabularyTerm # If we can adequately represent all needed relations in RO, this could be ROTerm
-      object:
-        range: GenomicEntity
       evidence:
         required: false # This needs to be not required, at least in the base class
 
@@ -526,18 +543,18 @@ classes:
       - note_dto
 
   AlleleImageAssociation:
-    is_a: EvidenceAssociation
+    is_a: AlleleAssociation
     description: >-
       The relationship between an allele and an image.
     slots:
       - primary_image
+    attributes:
+      allele_image_association_object:
+        range: Image
+        required: true
     slot_usage:
-      subject:
-        range: Allele
       relation:
         range: VocabularyTerm
-      object:
-        range: Image
       primary_image:
         description: >-
           Can be null; if false, maybe you would show all the images.
@@ -559,14 +576,13 @@ classes:
           We need to revisit this issue.
 
   AlleleOriginAssociation:
-    is_a: EvidenceAssociation
+    is_a: AlleleAssociation
     description: >-
       The relationship between an allele and the origin of the allele.
-    slot_usage:
-      subject:
-        range: Allele
-      object:
+    attributes:
+      allele_origin_association_object:
         range: AffectedGenomicModel
+        required: true
 
   AlleleOriginAssociationDTO:
     is_a: EvidenceAssociationDTO
@@ -581,9 +597,11 @@ classes:
     is_a: AlleleGenomicEntityAssociation
     description: >-
       Association between an allele and a protein
-    slot_usage:
-      object:
+    attributes:
+      allele_protein_association_object:
         range: Protein
+        required: true
+    
 
   AlleleProteinAssociationDTO:
     is_a: AlleleGenomicEntityAssociationDTO
@@ -596,9 +614,11 @@ classes:
     is_a: AlleleGenomicEntityAssociation
     description: >-
       Association between an allele and a transcript
-    slot_usage:
-      object:
+    attributes:
+      allele_transcript_association_object:
         range: Transcript
+        required: true
+    
 
   AlleleTranscriptAssociationDTO:
     is_a: AlleleGenomicEntityAssociationDTO
@@ -613,12 +633,11 @@ classes:
       The relationship between an allele and a variant is many to many. An
       Allele may have many variants and a variant can be present in many
       alleles.
-    slot_usage:
-      subject:
-        range: Allele
-      object:
+    attributes:
+      allele_variant_association_object:
         range: Variant
-
+        required: true
+    
   AlleleVariantAssociationDTO:
     is_a: AlleleGenomicEntityAssociationDTO
     description: >-

--- a/model/schema/biologicalEntitySet.yaml
+++ b/model/schema/biologicalEntitySet.yaml
@@ -131,15 +131,17 @@ classes:
       - proteins
 
 
-  GeneToPathwayAssociation:
+  GenePathwayAssociation:
     is_a: EvidenceAssociation
+    slots:
+      - gene_association_subject
+    attributes:
+      gene_pathway_association_object:
+        range: Pathway
+        required: true
     slot_usage:
       relation:
         subproperty_of: has_participant
-      subject:
-        range: Gene
-      object:
-        range: Pathway
 
 
 ## ------------

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -325,21 +325,17 @@ classes:
       of the association, and likewise the object is the curie (or identifier of the class that is the object. The
       relationship between subject and object is defined by the relation slot (which can also be constrained
       using the range of the relation).
-    exact_mappings:
-      - biolink:association
     notes:
       Keeping this more generic than biolink:association by foregoing the
       qualifiers and negated slots.
+      Association child classes must also have subject and object slots defined, but (due to implementation issues)
+      these must have distinct names if the range of the slot inherits from a different base table in the database.
+      Therefore these are defined in the appropriate classes with a prefix indicating the class(es) using the slot, 
+      e.g. disease_annotation_subject, allele_association_subject, allele_construct_association_object.
     slots:
-      - subject
       - relation
-      - object
     slot_usage:
-        subject:
-            required: true
         relation:
-            required: true
-        object:
             required: true
 
   SingleReferenceAssociation:
@@ -1199,25 +1195,6 @@ slots:
   ## --------------------
 ## ASSOCIATION SLOTS
 ## --------------------
-
-  subject:
-    is_a: association_slot
-    description: >-
-      connects an association to the subject of the association.
-      For example, in a gene-to-phenotype association, the gene is subject and phenotype is object.
-    required: true
-    exact_mappings:
-      - owl:annotatedSource
-      - biolink:subject
-
-  object:
-    is_a: association_slot
-    description: >-
-      connects an association to the object of the association.
-      For example, in a gene-to-phenotype association, the gene is subject and phenotype is object.
-    required: true
-    exact_mappings:
-      - biolink:object
 
   relation:
     is_a: association_slot

--- a/model/schema/expression.yaml
+++ b/model/schema/expression.yaml
@@ -131,17 +131,25 @@ classes:
       - cellular_component
       - spatial_qualifiers
 
-  ExpressionAnnotationImagePane:
+  ExpressionAnnotationAssociation:
+    is_a: EvidenceAssociation
+    abstract: true
+    description: Base class for all ExpressionAnnotation associations
+    attributes:
+      expression_annotation_subject:
+        required: true
+        domain: ExpressionAnnotation
+
+  ExpressionAnnotationImagePaneAssociation:
     is_a: EvidenceAssociation
     notes: >-
       This aims to provide the same functionality as MGI imagepane.
       Some MODs (like ZFIN) point to the whole image. In these cases,
       the pane would encompass the whole image.
-    slot_usage:
-      subject:
-        range: ExpressionAnnotation
-      object:
+    attributes:
+      expression_annotation_image_pane_association_object:
         range: ImagePane
+        required: true
 
   # GeneExpressionStatement:
   #   is_a: EntityStatement     # Update to use Note class instead?

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -208,13 +208,14 @@ classes:
     is_a: LocationAssociation
     description: >-
       Location(s) of the gene on the genome.
+    attributes:
+      gene_genomic_location_association_object:
+        range: AssemblyComponent
+        required: true
     slots:
+      - gene_association_subject
       - strand
     slot_usage:
-      subject:
-        range: Gene
-      object:
-        range: AssemblyComponent
       evidence:
         notes: List all references that support a given location association.
       start:
@@ -237,14 +238,15 @@ classes:
       does this include genetic segregation studies?
       How do we handle location to specific chromosome arms? Different asso'n,
       or different slot here, etc?
+    attributes:
+      gene_chromosomal_location_association_object:
+        range: Chromosome
+        required: true
     slots:
+      - gene_association_subject
       - left_boundary_marker
       - right_boundary_marker
     slot_usage:
-      subject:
-        range: Gene
-      object:
-        range: Chromosome
       relation:
         any_of:
           - equals_string: has_location
@@ -259,15 +261,16 @@ classes:
       Should this be limited to reports of specific cM on a given chromosome,
       or should it include genetic segregation studies that link gene to a
       chromosome?
-    slot_usage:
-      subject:
-        range: Gene
-      object:
+    attributes:
+      gene_genetic_map_association_object:
         range: Chromosome
+        required: true
+    slot_usage:
       relation:
         any_of:
           - equals_string: has_location
     slots:
+      - gene_association_subject
       - genetic_map_position_centimorgan
       - genetic_map_position_centimorgan_error
 
@@ -277,6 +280,12 @@ classes:
 
 slots:
 
+  gene_association_subject:
+    description: >-
+      Subject slot to be used for gene associations
+    required: true
+    range: Gene
+  
   left_boundary_marker:
     description: >-
       The left boundary of a feature location relative to the landmark's

--- a/model/schema/geneInteraction.yaml
+++ b/model/schema/geneInteraction.yaml
@@ -64,6 +64,8 @@ classes:
           the object gene in the association. If the relation is symmetric,
           subject vs object is arbitrary. We allow a gene product to stand
           as a proxy for the gene or vice versa.
+    slots:
+      - gene_association_subject
     slot_usage:
       gene_association_subject:
         description: >-
@@ -73,7 +75,7 @@ classes:
 #    exact_mappings:
 #      - biolink:GeneToGeneAssociation
 
-  GeneToGeneAssociationDTO:
+  GeneGeneAssociationDTO:
     is_a: AuditedObjectDTO
     slots:
       - subject_gene_identifier

--- a/model/schema/geneInteraction.yaml
+++ b/model/schema/geneInteraction.yaml
@@ -131,7 +131,7 @@ classes:
 #      - biolink:PairwiseGeneToGeneInteraction
 
   GeneInteractionDTO:
-    is_a: GeneToGeneAssociationDTO
+    is_a: GeneGeneAssociationDTO
     abstract: true
     description: >-
       Ingest class for an interaction between two genes or gene products; this may be a physical
@@ -369,7 +369,7 @@ slots:
 
   object_gene_identifier:
     description: Identifier (curie/mod_entity_id/mod_internal_id) of the object gene in a gene-to-gene association
-    domain: GeneToGeneAssociationDTO
+    domain: GeneGeneAssociationDTO
     range: string
     required: true
 
@@ -381,7 +381,7 @@ slots:
 
   subject_gene_identifier:
     description: Identifier (curie/mod_entity_id/mod_internal_id) of the subject gene in a gene-to-gene association
-    domain: GeneToGeneAssociationDTO
+    domain: GeneGeneAssociationDTO
     range: string
     required: true
 

--- a/model/schema/geneInteraction.yaml
+++ b/model/schema/geneInteraction.yaml
@@ -50,33 +50,30 @@ classes:
   ## ASSOCIATIONS
   ## ------------
 
-  GeneToGeneAssociation:
+  GeneGeneAssociation:
     description: >-
       abstract parent class for different kinds of gene-gene or gene product
       to gene product relationships. Includes homology and interaction.
     abstract: true
     is_a: EvidenceAssociation
-    defining_slots:
-      - subject
-      - object
-    slot_usage:
-      subject:
+    attributes:
+      gene_gene_association_object:
         range: Gene
-        description: >-
-          the subject gene in the association. If the relation is symmetric,
-          subject vs object is arbitrary. We allow a gene product to stand
-          as a proxy for the gene or vice versa.
-      object:
-        range: Gene
+        required: true
         description: >-
           the object gene in the association. If the relation is symmetric,
+          subject vs object is arbitrary. We allow a gene product to stand
+          as a proxy for the gene or vice versa.
+    slot_usage:
+      gene_association_subject:
+        description: >-
+          the subject gene in the association. If the relation is symmetric,
           subject vs object is arbitrary. We allow a gene product to stand
           as a proxy for the gene or vice versa.
 #    exact_mappings:
 #      - biolink:GeneToGeneAssociation
 
   GeneToGeneAssociationDTO:
-    abstract: true
     is_a: AuditedObjectDTO
     slots:
       - subject_gene_identifier
@@ -89,7 +86,7 @@ classes:
       An interaction between two genes or gene products; this may be a physical
       molecular interaction between gene products (e.g. protein-protein interactions),
       or may be a genetic interaction between genes (e.g. phenotypic suppression)
-    is_a: GeneToGeneAssociation
+    is_a: GeneGeneAssociation
     abstract: true
     slots:
       - curie
@@ -101,9 +98,9 @@ classes:
       - interactor_A_type
       - interactor_B_type
     defining_slots:
-      - subject
+      - gene_association_subject
       - relation
-      - object
+      - gene_gene_association_object
     id_prefixes:
       - BIOGRID
       - DIP

--- a/model/schema/ontologyTerm.yaml
+++ b/model/schema/ontologyTerm.yaml
@@ -102,13 +102,6 @@ slots:
       like "develops_from", ancestors are the terms to which this term develops into (not a true
       parent/child or ancestor/descendant relationship).
 
-  relationship_type:
-    range: string
-    multivalued: true
-
-  distance_between:
-    range: integer
-
   child_count:
     range: integer
 
@@ -164,18 +157,21 @@ classes:
 
   OntologyTermClosure:
     is_a: EvidenceAssociation
-    slots:
-      - relationship_type
-      - distance_between
-    slot_usage:
-      subject:
+    attributes:
+      ontology_term_closure_subject:
         range: OntologyTerm
-      object:
+        required: true
+      ontology_term_closure_object:
         range: OntologyTerm
+        required: true
       distance_between:
+        range: integer
         description: >-
           distance_between is zero for reflexive–transitive closure
           each node has an ancestor or descendant of itself
+      relationship_type:
+        range: string
+        multivalued: true
 
   DOTerm:
     is_a: OntologyTerm

--- a/model/schema/orthology.yaml
+++ b/model/schema/orthology.yaml
@@ -40,7 +40,6 @@ classes:
 
   GeneToGeneOrthology:
     is_a: AuditedObject
-    description: >-
     slots:
       - subject_gene
       - object_gene

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -64,12 +64,8 @@ classes:
       - related_notes
       - data_provider
     slot_usage:
-        subject:
-            required: true
-        object:
-            required: true
-        single_reference:
-            required: true
+      single_reference:
+        required: true
 
   AnnotationDTO:
     is_a: SingleReferenceAssociationDTO
@@ -91,13 +87,16 @@ classes:
     description: >-
       An annotation asserting an association between a biological entity and a phenotype supported by evidence.
     slots:
+      - phenotype_annotation_subject
       - phenotype_term
-    slot_usage:
-      subject:                            # objectId in JSON schema
+    attributes:
+      phenotype_annotation_object:
         description: >-
-          The biological entity (e.g. gene, allele, genotype) to which the phenotype is associated, by direct curation.
+          phenotype statement: The label of an individual phenotype term from a phenotype ontology or the post-composed
+          statement of the phenotype from a post-composed terminology
         required: true
-        range: BiologicalEntity
+        range: string
+    slot_usage:
       phenotype_term:
         values_from:
           - HP
@@ -114,12 +113,6 @@ classes:
             description: axon morphology variant
           - value: MP:0001569
             description: abnormal circulating bilirubin level
-      object:             # phenotypeStatement in JSON schema; eventually object should point to Phenotype class object
-        description: >-
-          phenotype statement: The label of an individual phenotype term from a phenotype ontology or the post-composed
-          statement of the phenotype from a post-composed terminology
-        required: true
-        range: string
       single_reference:
         description: >-
           The reference in which the phenotype association was asserted/reported.
@@ -152,8 +145,7 @@ classes:
     slots:
       - sgd_strain_background   # Does this also apply to phenotype annotations?
     slot_usage:
-      subject:
-        required: true
+      phenotype_annotation_subject:
         description: >-
           The gene to which the phenotype ontology term is associated.
         range: Gene
@@ -175,7 +167,7 @@ classes:
       - inferred_gene
       - asserted_genes
     slot_usage:
-      subject:
+      phenotype_annotation_subject:
         description: >-
           The allele to which the phenotype ontology term is associated.
         range: Allele
@@ -209,7 +201,7 @@ classes:
       - asserted_genes
       - asserted_allele
     slot_usage:
-      subject:
+      phenotype_annotation_subject:
         description: >-
           The AGM to which the phenotype ontology term is associated.
         range: AffectedGenomicModel
@@ -227,6 +219,7 @@ classes:
         required: false
       asserted_allele:
         required: false
+
   AGMPhenotypeAnnotationDTO:
     is_a: PhenotypeAnnotationDTO
     description: >-
@@ -243,7 +236,13 @@ classes:
     abstract: true
     description: >-
       An annotation asserting an association between a biological entity and a disease supported by evidence.
+    attributes:
+      disease_annotation_object:
+        description: The Disease Ontology term
+        range: DOTerm
+        required: true
     slots:
+      - disease_annotation_subject
       - negated
       - evidence_codes
       - annotation_type
@@ -274,19 +273,9 @@ classes:
           The model organism database (MOD) internal identifier for the disease annotation. When available,
           this is used for determination of distinctness instead of the Unique ID field.
         required: false
-      subject:
-        required: true
-        description: >-
-          The biological entity to which the disease ontology term is associated.
-        range: BiologicalEntity
       negated:
         description: >-
           The negative qualifier for the annotation.
-      object:
-        required: true
-        description: >-
-          The disease ontology term.
-        range: DOTerm
       relation:
         description: >-
           The relation between the subject biological entity and disease in the annotation.
@@ -349,7 +338,7 @@ classes:
     slots:
       - sgd_strain_background
     slot_usage:
-      subject:
+      disease_annotation_subject:
         required: true
         description: >-
           The gene to which the disease ontology term is associated.
@@ -378,7 +367,7 @@ classes:
       - inferred_gene
       - asserted_genes
     slot_usage:
-      subject:
+      disease_annotation_subject:
         description: >-
           The allele to which the disease ontology term is associated.
         range: Allele
@@ -417,7 +406,7 @@ classes:
       - asserted_genes
       - asserted_allele
     slot_usage:
-      subject:
+      disease_annotation_subject:
         description: >-
           The AGM to which the disease ontology term is associated.
         range: AffectedGenomicModel
@@ -739,6 +728,13 @@ slots:
     inlined: true
     inlined_as_list: true
 
+  disease_annotation_subject:
+    required: true
+    description: >-
+      The biological entity to which the disease ontology term is associated.
+    domain: DiseaseAnnotation
+    range: BiologicalEntity
+      
   disease_genetic_modifiers:
     description: >-
       Specifies a genetic object that modifies the disease model. May be a gene, allele, AGM.
@@ -820,6 +816,13 @@ slots:
       automated pipeline
     range: string
 
+  phenotype_annotation_subject:
+    description: >-
+      The biological entity (e.g. gene, allele, genotype) to which the phenotype is associated, by direct curation.
+    required: true
+    domain: PhenotypeAnnotation
+    range: BiologicalEntity
+  
   phenotype_term:
     description: >-
       The phenotype ontology term used to describe the phenotype of an organism

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -257,25 +257,34 @@ classes:
       single_construct:
         required: true
 
-  ConstructGenomicEntityAssociation:
+  ConstructAssociation:
+    abstract: true
     is_a: EvidenceAssociation
+    description: Base class for construct associations
+    attributes:
+      construct_association_subject:
+        range: Construct
+        required: true
+
+  ConstructGenomicEntityAssociation:
+    is_a: ConstructAssociation
     description: >-
       An association class to capture the identity of a construct component that is
       a known genomic entity with a curie and any accompanying meta data about the
       relationship between the construct and that genomic entity component
+    attributes:
+      construct_genomic_entity_association_object:
+        range: GenomicEntity
+        required: true
     slots:
       - related_notes
     slot_usage:
-      subject:
-        range: Construct
       relation:
         range: VocabularyTerm
         notes: >-
           The relation should be a VocabularyTerm with one of the following
           values - expresses (RO:0002292) / is_regulated_by (RO:0002334) /
           targets (RO:0002436). CV: 'Construct Genomic Entity Association Relation'
-      object:
-        range: GenomicEntity
       related_notes:
         required: false
 

--- a/model/schema/variantConsequence.yaml
+++ b/model/schema/variantConsequence.yaml
@@ -46,8 +46,6 @@ classes:
       consequences
     abstract: true
     slots:
-      - subject
-      - object
       - vep_consequence
       - vep_impact
       - polyphen_score
@@ -60,10 +58,10 @@ classes:
     description: >-
       Class for gene-level VEP results
     is_a: VariantConsequence
-    slot_usage:
-      object:
+    attributes:
+      variant_gene_consequence_object:
         range: Gene
-      subject:
+      variant_gene_consequence_subject:
         range: VariantGenomicLocationAssociation
 
   VariantTranscriptConsequence:
@@ -71,6 +69,11 @@ classes:
     is_a: VariantConsequence
     description: >-
       Class for transcript-level VEP results
+    attributes:
+      variant_transcript_consequence_object:
+        range: Transcript
+      variant_transcript_consequence_subject:
+        range: VariantTranscriptLocationAssociation 
     slots:
       - amino_acid_reference
       - amino_acid_variant
@@ -85,10 +88,6 @@ classes:
       - hgvs_protein_nomenclature
       - hgvs_coding_nomenclature
     slot_usage:
-      object:
-        range: Transcript
-      subject:
-        range: VariantTranscriptLocationAssociation
       amino_acid_reference:
         description: >-
           Amino acid sequence encoded by codon(s) in reference genome sequence

--- a/model/schema/variation.yaml
+++ b/model/schema/variation.yaml
@@ -76,16 +76,14 @@ classes:
       the definition of the transcript or protein isoform used by the source has changed, or if there was an error
       in the source data.
     slots:
+      - variant_association_subject
       - hgvs
       - reference_sequence
       - variant_sequence
       - consequence
       - curated_consequence
       - sequence_of_reference_accession_number # Should this point to a chromosome object instead of a string? Will this be redundant with genomic location association of the subject?
-    slot_usage:
-      subject:
-        range: Variant
-
+    
   VariantGenomicLocationAssociation:
     is_a: VariantLocationAssociation
     abstract: true
@@ -102,8 +100,8 @@ classes:
       - padded_base
       - dna_mutation_type
       - gene_localization_type
-    slot_usage:
-      object:
+    attributes:
+      variant_genomic_location_association_object:
         description: >-
           The location reference object should be a chromosome assembly curie.
         range: AssemblyComponent
@@ -118,8 +116,8 @@ classes:
     slots:
       - exon_number
       - intron_number
-    slot_usage:
-      object:
+    attributes:
+      variant_transcript_location_object:
         description: >-
           Transcript associated with variant and for which a specific location and consequence of that variant
           is provided, as specified at source.  Multivalued=false for this slot because although a variant can have
@@ -139,8 +137,8 @@ classes:
       - associated_transcripts # won't this be a property of the protein objects?
       - number_amino_acids_removed
       - number_amino_acids_inserted
-    slot_usage:
-      object:
+    attributes:
+      variant_polypeptide_location_association_object:
         description: >-
           Polypeptide associated with variant and for which a specific location and consequence of that variant is
           provided, as specified by curator. Multivalued=false for this slot because although a variant can have
@@ -227,6 +225,12 @@ classes:
 # Slots
 
 slots:
+  variant_association_subject:
+    description: >-
+      Subject slot to be used for variant associations
+    required: true
+    range: Variant
+  
   number_amino_acids_removed:
     description: >-
       The number of amino acids removed from the polypeptide as a result of the variant.

--- a/test/data/ontology_closure_test.json
+++ b/test/data/ontology_closure_test.json
@@ -2,32 +2,32 @@
   "linkml_version": "2.0.0",
   "ontology_closure_ingest_set": [
     {
-      "subject": "ZFA:brain",
-      "object": "ZFA:cavitated_compound_organ",
+      "ontology_term_closure_subject": "ZFA:brain",
+      "ontology_term_closure_object": "ZFA:cavitated_compound_organ",
       "relation": "RO:is_a",
       "internal": false
     },
     {
-      "subject": "ZFA:brain",
-      "object": "ZFA:compound_organ",
+      "ontology_term_closure_subject": "ZFA:brain",
+      "ontology_term_closure_object": "ZFA:compound_organ",
       "relation": "RO:is_a",
       "internal": false
     },
     {
-      "subject": "ZFA:brain",
-      "object": "ZFA:anatomical_structure",
+      "ontology_term_closure_subject": "ZFA:brain",
+      "ontology_term_closure_object": "ZFA:anatomical_structure",
       "relation": "RO:is_a",
       "internal": false
     },
     {
-      "subject": "ZFA:brain",
-      "object": "ZFA:zebrafish_anatomical_entity",
+      "ontology_term_closure_subject": "ZFA:brain",
+      "ontology_term_closure_object": "ZFA:zebrafish_anatomical_entity",
       "relation": "RO:is_a",
       "internal": false
     },
     {
-      "subject": "ZFA:brain",
-      "object": "ZFA:whole_organism",
+      "ontology_term_closure_subject": "ZFA:brain",
+      "ontology_term_closure_object": "ZFA:whole_organism",
       "relation": [
         "RO:is_a",
         "RO:part_of"
@@ -35,8 +35,8 @@
       "internal": false
     },
     {
-      "subject": "ZFA:brain",
-      "object": "ZFA:whole_organism",
+      "ontology_term_closure_subject": "ZFA:brain",
+      "ontology_term_closure_object": "ZFA:whole_organism",
       "relation": [
         "RO:is_a",
         "RO:part_of"


### PR DESCRIPTION
Alternative version of association slot refactor using domain class prefix to differentiate, as discussed in sprint planning.  As per Sierra's suggestion, I've used "attributes" where possible to define slots inline in the classes if reuse of the slot is not intended.