### PR TITLE
Remove requirement of Paralogy identity, similarity, and length

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -15272,9 +15272,6 @@
                 "object_gene",
                 "rank",
                 "homology_confidence",
-                "length",
-                "similarity",
-                "identity",
                 "internal"
             ],
             "title": "GeneToGeneParalogy",

--- a/model/schema/homology.yaml
+++ b/model/schema/homology.yaml
@@ -148,15 +148,15 @@ slots:
   length:
     description: The length of the aligned regions between two genes
     range: integer
-    required: true
+    required: false
   
   similarity:
     description: Similarity score between the two genes
     range: integer
-    required: true
+    required: false
     
   identity:
     description: Identity score between the two genes
     range: integer
-    required: true
+    required: false
     


### PR DESCRIPTION
After discussing with @christabone who has discussed with DIOPT:

We will remove the requirement of Paralogous gene pairs to have a length, similarity, or identity scores.