### PR TITLE
Add cross reference to ExpressionExperiment

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -13345,6 +13345,9 @@
                     "description": "The individual that created the entity.",
                     "type": "string"
                 },
+                "cross_reference": {
+                    "$ref": "#/$defs/CrossReference"
+                },
                 "curie": {
                     "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
                     "type": "string"

--- a/model/schema/expression.yaml
+++ b/model/schema/expression.yaml
@@ -58,6 +58,7 @@ classes:
       This entity is originally specific to WB and MGI.
     slots:
       - unique_id
+      - cross_reference
       - single_reference
       - entity_assayed
       - expression_assay_used


### PR DESCRIPTION
Simple addition of a 'cross_reference' slot to ExpressionExperiment class