### PR TITLE
Added required content write permissions to handle new read-only default

### DIFF
--- a/.github/workflows/build-deploy-documentation.yaml
+++ b/.github/workflows/build-deploy-documentation.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   github-pages:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       #----------------------------------------------

--- a/.github/workflows/build-deploy-documentation.yaml
+++ b/.github/workflows/build-deploy-documentation.yaml
@@ -19,10 +19,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -15,10 +15,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/regenerate_artifacts.yaml
+++ b/.github/workflows/regenerate_artifacts.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   generate-artifacts:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout

--- a/.github/workflows/regenerate_artifacts.yaml
+++ b/.github/workflows/regenerate_artifacts.yaml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Python Environment
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
           python-version: 3.9
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '8'


### PR DESCRIPTION
These permission definitions are now required in all GH actions workflow files to enable workflows to write to their repository where needed (and only where needed), as the default permissions have been update to read-only access to the repository contents.