### PR TITLE
recognize casing of Ingest class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ $(TARGET_DIR)/graphql/%.graphql: $(SCHEMA_DIR)/%.yaml tdir-graphql
 gen-jsonschema: $(TARGET_DIR)/jsonschema/$(SCHEMA_NAME).schema.json
 .PHONY: gen-jsonschema
 $(TARGET_DIR)/jsonschema/%.schema.json: $(SCHEMA_DIR)/%.yaml tdir-jsonschema
-	poetry run gen-json-schema $(GEN_OPTS) --indent 4 --closed -t ingest $< > $@
+	poetry run gen-json-schema $(GEN_OPTS) --indent 4 --closed -t Ingest $< > $@
 
 
 ###  -- SQL --


### PR DESCRIPTION
WARNING:linkml.generators.jsonschemagen:No class in schema named ingest
cp -pr generated/target/jsonschema generated/

better warning message in more recent versions of linkml notified us that we need to update the casing of "Ingest" class in order to be recognized as a valid class in agr_curation_schema. 