### PR TITLE
Add GCRP cross reference

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -20582,6 +20582,17 @@
                         "null"
                     ]
                 },
+                "gcrp_cross_reference": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/CrossReference"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The single UniProtKB Gene-Centric Reference Proteome (GCRP) UniProtKB identifier and cross reference for the gene"
+                },
                 "gene_change_events": {
                     "description": "Change events for a given gene.",
                     "items": {
@@ -21388,6 +21399,17 @@
                         "string",
                         "null"
                     ]
+                },
+                "gcrp_cross_reference_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/CrossReferenceDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The single UniProtKB Gene-Centric Reference Proteome (GCRP) UniProtKB identifier and cross reference for the gene, data transfer object for submission"
                 },
                 "gene_full_name_dto": {
                     "anyOf": [

--- a/model/schema/gene.yaml
+++ b/model/schema/gene.yaml
@@ -75,6 +75,14 @@ classes:
       - product_binds_matrix
       - wbprocess
       - transposon_origin
+    attributes:
+      gcrp_cross_reference:
+        range: CrossReference
+        description: >-
+          The single UniProtKB Gene-Centric Reference Proteome (GCRP) UniProtKB identifier
+          and cross reference for the gene
+        multivalued: false
+        required: false
     id_prefixes:
       - ENSEMBL
       - HGNC
@@ -105,6 +113,14 @@ classes:
       - gene_secondary_id_dtos
       - gene_type_curie
       - note_dtos
+    attributes:
+      gcrp_cross_reference_dto:
+        range: CrossReferenceDTO
+        description: >-
+          The single UniProtKB Gene-Centric Reference Proteome (GCRP) UniProtKB identifier
+          and cross reference for the gene, data transfer object for submission
+        multivalued: false
+        required: false
     slot_usage:
       primary_external_id:
         required: true

--- a/test/data/gene_test.json
+++ b/test/data/gene_test.json
@@ -73,6 +73,13 @@
           "internal": false
         }
       ],
+      "gcrp_cross_reference_dto": {
+        "referenced_curie": "UniProtKB:P18431",
+        "display_name": "UniProtKB:P18431",
+        "internal": false,
+        "page_area": "default",
+        "prefix": "UniProtKB"
+      },
       "cross_reference_dtos": [
         {
           "referenced_curie": "ZFIN:ZDB-GENE-010226-1",


### PR DESCRIPTION
Curators have requested a way to unambiguously identify and display a gene's single Gene Centric Reference Proteome (GCRP) ID from UniProt. Relates to
https://agr-jira.atlassian.net/browse/KANBAN-436

As discussed and agreed among curators and DQMs, this PR adds the gcrp_cross_reference (and supporting) fields to the Gene & GeneDTO classes, test data included in test/data/gene_test.json