### PR TITLE
KANBAN-838: Allow structured, post-composed phenotype annotations (alternative model).

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -33351,6 +33351,13 @@
                         "null"
                     ]
                 },
+                "qualifier_tag": {
+                    "description": "Similar to qualifier_term, but using a term from a vocabulary rather than a dedicated ontology. Intended for \"simple\" qualifications such as \"abnormal\", \"ameliorated\", \"exacerbated\", etc.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "qualifier_term": {
                     "description": "The main ontological term that refines the description of a phenotype."
                 },
@@ -33374,9 +33381,28 @@
                 }
             },
             "required": [
-                "qualifier_term",
                 "internal"
             ],
+            "then": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "qualifier_term": {}
+                        },
+                        "required": [
+                            "qualifier_term"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "qualifier_tag": {}
+                        },
+                        "required": [
+                            "qualifier_tag"
+                        ]
+                    }
+                ]
+            },
             "title": "PhenotypeQualifier",
             "type": "object"
         },
@@ -33434,8 +33460,17 @@
                         "null"
                     ]
                 },
+                "qualifier_tag_name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "qualifier_term_curie": {
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "related_entity": {
                     "anyOf": [
@@ -33456,9 +33491,28 @@
                 }
             },
             "required": [
-                "qualifier_term_curie",
                 "internal"
             ],
+            "then": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "qualifier_term_curie": {}
+                        },
+                        "required": [
+                            "qualifier_term_curie"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "qualifier_tag_name": {}
+                        },
+                        "required": [
+                            "qualifier_tag_name"
+                        ]
+                    }
+                ]
+            },
             "title": "PhenotypeQualifierDTO",
             "type": "object"
         },

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -551,6 +551,17 @@
             "additionalProperties": false,
             "description": "An annotation asserting an association between an AGM and a phenotype supported by evidence.",
             "properties": {
+                "affected_entity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The entity (anatomical structure, developmental stage, and/or biological process) that is affected by the phenotype."
+                },
                 "asserted_alleles": {
                     "description": "The allele to which something is manually asserted to be associated.",
                     "items": {
@@ -734,6 +745,17 @@
                         "null"
                     ]
                 },
+                "qualifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PhenotypeQualifier"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Additional ontological terms that refine the description of the phenotype."
+                },
                 "related_notes": {
                     "description": "Valid note types are available for viewing in the A-Team curation tool Controlled Vocabulary Terms Table (in the \"Phenotype annotation note types\" vocabulary) on the production environment (curation.alliancegenome.org). New terms can be added as needed.",
                     "items": {
@@ -777,6 +799,16 @@
             "additionalProperties": false,
             "description": "Ingest class for an association between an AGM and a phenotype",
             "properties": {
+                "affected_entity_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntityDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "agm_identifier": {
                     "description": "Curie or internal ID of AGM",
                     "type": "string"
@@ -940,6 +972,16 @@
                     "type": [
                         "string",
                         "null"
+                    ]
+                },
+                "qualifier_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PhenotypeQualifierDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
                     ]
                 },
                 "updated_by_curie": {
@@ -1328,6 +1370,253 @@
                 "internal"
             ],
             "title": "ATPTerm",
+            "type": "object"
+        },
+        "AffectedEntity": {
+            "additionalProperties": false,
+            "description": "An entity that is affected by a phenotype.",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "location": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AnatomicalSite"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The anatomical site that is affected by a phenotype."
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "process": {
+                    "description": "The biological process that is affected by a phenotype.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "stage": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TemporalContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The developmental stage that is affected by a phenotye."
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "internal"
+            ],
+            "then": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "location": {}
+                        },
+                        "required": [
+                            "location"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "stage": {}
+                        },
+                        "required": [
+                            "stage"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "process": {}
+                        },
+                        "required": [
+                            "process"
+                        ]
+                    }
+                ]
+            },
+            "title": "AffectedEntity",
+            "type": "object"
+        },
+        "AffectedEntityDTO": {
+            "additionalProperties": false,
+            "description": "Ingest class for an entity that is affected by a phenotype.",
+            "properties": {
+                "created_by_curie": {
+                    "description": "Curie of the Person object representing the individual that created the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "location_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AnatomicalSiteDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "process_curie": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "stage_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TemporalContextDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "updated_by_curie": {
+                    "description": "Curie of the Person object representing the individual that updated the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "internal"
+            ],
+            "then": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "location_dto": {}
+                        },
+                        "required": [
+                            "location_dto"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "stage_dto": {}
+                        },
+                        "required": [
+                            "stage_dto"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "process_curie": {}
+                        },
+                        "required": [
+                            "process_curie"
+                        ]
+                    }
+                ]
+            },
+            "title": "AffectedEntityDTO",
             "type": "object"
         },
         "AffectedGenomicModel": {
@@ -6351,6 +6640,17 @@
             "additionalProperties": false,
             "description": "An annotation asserting an association between an allele and a phenotype supported by evidence.",
             "properties": {
+                "affected_entity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The entity (anatomical structure, developmental stage, and/or biological process) that is affected by the phenotype."
+                },
                 "asserted_genes": {
                     "description": "The gene(s) to which something is manually asserted to be associated.",
                     "items": {
@@ -6513,6 +6813,17 @@
                         "null"
                     ]
                 },
+                "qualifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PhenotypeQualifier"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Additional ontological terms that refine the description of the phenotype."
+                },
                 "related_notes": {
                     "description": "Valid note types are available for viewing in the A-Team curation tool Controlled Vocabulary Terms Table (in the \"Phenotype annotation note types\" vocabulary) on the production environment (curation.alliancegenome.org). New terms can be added as needed.",
                     "items": {
@@ -6556,6 +6867,16 @@
             "additionalProperties": false,
             "description": "Ingest class for an association between an allele and a phenotype",
             "properties": {
+                "affected_entity_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntityDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "allele_identifier": {
                     "description": "Identifier (curie/primary_external_id/mod_internal_id) of the allele",
                     "type": "string"
@@ -6702,6 +7023,16 @@
                     "type": [
                         "string",
                         "null"
+                    ]
+                },
+                "qualifier_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PhenotypeQualifierDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
                     ]
                 },
                 "updated_by_curie": {
@@ -24700,6 +25031,17 @@
             "additionalProperties": false,
             "description": "An annotation asserting an association between a gene and a phenotype supported by evidence.",
             "properties": {
+                "affected_entity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The entity (anatomical structure, developmental stage, and/or biological process) that is affected by the phenotype."
+                },
                 "condition_relations": {
                     "items": {
                         "$ref": "#/$defs/ConditionRelation"
@@ -24841,6 +25183,17 @@
                         "null"
                     ]
                 },
+                "qualifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PhenotypeQualifier"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Additional ontological terms that refine the description of the phenotype."
+                },
                 "related_notes": {
                     "description": "Valid note types are available for viewing in the A-Team curation tool Controlled Vocabulary Terms Table (in the \"Phenotype annotation note types\" vocabulary) on the production environment (curation.alliancegenome.org). New terms can be added as needed.",
                     "items": {
@@ -24894,6 +25247,16 @@
             "additionalProperties": false,
             "description": "Ingest class for an association between a gene and a phenotype",
             "properties": {
+                "affected_entity_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntityDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "condition_relation_dtos": {
                     "items": {
                         "$ref": "#/$defs/ConditionRelationDTO"
@@ -25023,6 +25386,16 @@
                     "type": [
                         "string",
                         "null"
+                    ]
+                },
+                "qualifier_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PhenotypeQualifierDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
                     ]
                 },
                 "sgd_strain_background_identifier": {
@@ -32722,6 +33095,17 @@
             "additionalProperties": false,
             "description": "An annotation asserting an association between a biological entity and a phenotype supported by evidence.",
             "properties": {
+                "affected_entity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The entity (anatomical structure, developmental stage, and/or biological process) that is affected by the phenotype."
+                },
                 "condition_relations": {
                     "items": {
                         "$ref": "#/$defs/ConditionRelation"
@@ -32863,6 +33247,17 @@
                         "null"
                     ]
                 },
+                "qualifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PhenotypeQualifier"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Additional ontological terms that refine the description of the phenotype."
+                },
                 "related_notes": {
                     "description": "Valid note types are available for viewing in the A-Team curation tool Controlled Vocabulary Terms Table (in the \"Phenotype annotation note types\" vocabulary) on the production environment (curation.alliancegenome.org). New terms can be added as needed.",
                     "items": {
@@ -32900,6 +33295,171 @@
                 "internal"
             ],
             "title": "PhenotypeAnnotation",
+            "type": "object"
+        },
+        "PhenotypeQualifier": {
+            "additionalProperties": false,
+            "description": "Ontological terms that refine the description of a phenotype.",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "qualifier_term": {
+                    "description": "The main ontological term that refines the description of a phenotype."
+                },
+                "related_entity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "An affected entity that further refines the description of a phenotype."
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "qualifier_term",
+                "internal"
+            ],
+            "title": "PhenotypeQualifier",
+            "type": "object"
+        },
+        "PhenotypeQualifierDTO": {
+            "additionalProperties": false,
+            "description": "Ingest class for a phenotype qualifier.",
+            "properties": {
+                "created_by_curie": {
+                    "description": "Curie of the Person object representing the individual that created the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "qualifier_term_curie": {
+                    "type": "string"
+                },
+                "related_entity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AffectedEntityDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "updated_by_curie": {
+                    "description": "Curie of the Person object representing the individual that updated the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "qualifier_term_curie",
+                "internal"
+            ],
+            "title": "PhenotypeQualifierDTO",
             "type": "object"
         },
         "PhenotypeTerm": {

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -1419,7 +1419,14 @@
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
                 },
-                "location": {
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "phenotype_location": {
                     "anyOf": [
                         {
                             "$ref": "#/$defs/AnatomicalSite"
@@ -1430,21 +1437,14 @@
                     ],
                     "description": "The anatomical site that is affected by a phenotype."
                 },
-                "obsolete": {
-                    "description": "Entity is no longer current.",
-                    "type": [
-                        "boolean",
-                        "null"
-                    ]
-                },
-                "process": {
+                "phenotype_process": {
                     "description": "The biological process that is affected by a phenotype.",
                     "type": [
                         "string",
                         "null"
                     ]
                 },
-                "stage": {
+                "phenotype_stage": {
                     "anyOf": [
                         {
                             "$ref": "#/$defs/TemporalContext"
@@ -1453,7 +1453,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The developmental stage that is affected by a phenotye."
+                    "description": "The developmental stage that is affected by a phenotype."
                 },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
@@ -1470,26 +1470,26 @@
                 "anyOf": [
                     {
                         "properties": {
-                            "location": {}
+                            "phenotype_location": {}
                         },
                         "required": [
-                            "location"
+                            "phenotype_location"
                         ]
                     },
                     {
                         "properties": {
-                            "stage": {}
+                            "phenotype_stage": {}
                         },
                         "required": [
-                            "stage"
+                            "phenotype_stage"
                         ]
                     },
                     {
                         "properties": {
-                            "process": {}
+                            "phenotype_process": {}
                         },
                         "required": [
-                            "process"
+                            "phenotype_process"
                         ]
                     }
                 ]
@@ -1544,16 +1544,6 @@
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
                 },
-                "location_dto": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/AnatomicalSiteDTO"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
                 "obsolete": {
                     "description": "Entity is no longer current.",
                     "type": [
@@ -1561,13 +1551,25 @@
                         "null"
                     ]
                 },
-                "process_curie": {
+                "phenotype_location_dto": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AnatomicalSiteDTO"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The anatomical site that is affected by a phenotype (submitted)."
+                },
+                "phenotype_process_curie": {
+                    "description": "The biological process that is affected by a phenotype (submitted).",
                     "type": [
                         "string",
                         "null"
                     ]
                 },
-                "stage_dto": {
+                "phenotype_stage_dto": {
                     "anyOf": [
                         {
                             "$ref": "#/$defs/TemporalContextDTO"
@@ -1575,7 +1577,8 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "description": "The developmental stage that is affected by a phenotype (submitted)."
                 },
                 "updated_by_curie": {
                     "description": "Curie of the Person object representing the individual that updated the entity",
@@ -1592,26 +1595,26 @@
                 "anyOf": [
                     {
                         "properties": {
-                            "location_dto": {}
+                            "phenotype_location_dto": {}
                         },
                         "required": [
-                            "location_dto"
+                            "phenotype_location_dto"
                         ]
                     },
                     {
                         "properties": {
-                            "stage_dto": {}
+                            "phenotype_stage_dto": {}
                         },
                         "required": [
-                            "stage_dto"
+                            "phenotype_stage_dto"
                         ]
                     },
                     {
                         "properties": {
-                            "process_curie": {}
+                            "phenotype_process_curie": {}
                         },
                         "required": [
-                            "process_curie"
+                            "phenotype_process_curie"
                         ]
                     }
                 ]
@@ -33351,17 +33354,21 @@
                         "null"
                     ]
                 },
-                "qualifier_tag": {
-                    "description": "Similar to qualifier_term, but using a term from a vocabulary rather than a dedicated ontology. Intended for \"simple\" qualifications such as \"abnormal\", \"ameliorated\", \"exacerbated\", etc.",
+                "phenotype_qualifier_tag": {
+                    "description": "Similar to phenotype_qualifier_term, but using a term from a vocabulary rather than a dedicated ontology. Intended for \"simple\" qualifications such as \"abnormal\", \"ameliorated\", \"exacerbated\", etc.",
                     "type": [
                         "string",
                         "null"
                     ]
                 },
-                "qualifier_term": {
-                    "description": "The main ontological term that refines the description of a phenotype."
+                "phenotype_qualifier_term": {
+                    "description": "The main ontological term that refines the description of a phenotype.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
-                "related_entity": {
+                "phenotype_related_entity": {
                     "anyOf": [
                         {
                             "$ref": "#/$defs/AffectedEntity"
@@ -33387,18 +33394,18 @@
                 "anyOf": [
                     {
                         "properties": {
-                            "qualifier_term": {}
+                            "phenotype_qualifier_term": {}
                         },
                         "required": [
-                            "qualifier_term"
+                            "phenotype_qualifier_term"
                         ]
                     },
                     {
                         "properties": {
-                            "qualifier_tag": {}
+                            "phenotype_qualifier_tag": {}
                         },
                         "required": [
-                            "qualifier_tag"
+                            "phenotype_qualifier_tag"
                         ]
                     }
                 ]
@@ -33472,7 +33479,7 @@
                         "null"
                     ]
                 },
-                "related_entity": {
+                "related_entity_dto": {
                     "anyOf": [
                         {
                             "$ref": "#/$defs/AffectedEntityDTO"

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -13,6 +13,7 @@ imports:
   - gene
   - allele
   - ontologyTerm
+  - expression
 
 
 prefixes:
@@ -83,6 +84,94 @@ classes:
       reference_curie:
         required: true
 
+  AffectedEntity:
+    is_a: AuditedObject
+    description: >-
+      An entity that is affected by a phenotype.
+    attributes:
+      location:
+        description: >-
+          The anatomical site that is affected by a phenotype.
+        range: AnatomicalSite
+      stage:
+        description: >-
+          The developmental stage that is affected by a phenotye.
+        range: TemporalContext
+      process:
+        description:
+          The biological process that is affected by a phenotype.
+        range: GOTerm # FIXME: Should ideally be restricted to the "process" branch
+    rules:
+      - postconditions:
+          any_of:
+            - slot_conditions:
+                location:
+                  required: true
+            - slot_conditions:
+                stage:
+                  required: true
+            - slot_conditions:
+                process:
+                  required: true
+
+  AffectedEntityDTO:
+    is_a: AuditedObjectDTO
+    description: >-
+      Ingest class for an entity that is affected by a phenotype.
+    attributes:
+      location_dto:
+        range: AnatomicalSiteDTO
+      stage_dto:
+        range: TemporalContextDTO
+      process_curie:
+        range: string
+    rules:
+      - postconditions:
+          any_of:
+            - slot_conditions:
+                location_dto:
+                  required: true
+            - slot_conditions:
+                stage_dto:
+                  required: true
+            - slot_conditions:
+                process_curie:
+                  required: true
+
+  PhenotypeQualifier:
+    is_a: AuditedObject
+    description: >-
+      Ontological terms that refine the description of a phenotype.
+    attributes:
+      qualifier_term:
+        description: >-
+          The main ontological term that refines the description of a phenotype.
+        range: OntologicalTerm
+        values_from:
+          - HP
+          - MP
+          - WBPhenotype
+          - ZP
+          - APO
+          - FBcv
+          - PATO
+        required: true
+      related_entity:
+        description: >-
+          An affected entity that further refines the description of a phenotype.
+        range: AffectedEntity
+
+  PhenotypeQualifierDTO:
+    is_a: AuditedObjectDTO
+    description: >-
+      Ingest class for a phenotype qualifier.
+    attributes:
+      qualifier_term_curie:
+        range: string
+        required: true
+      related_entity:
+        range: AffectedEntityDTO
+
   PhenotypeAnnotation:
     is_a: Annotation
     description: >-
@@ -99,6 +188,15 @@ classes:
           statement of the phenotype from a post-composed terminology
         required: true
         range: string
+      affected_entity:
+        description: >-
+          The entity (anatomical structure, developmental stage, and/or biological process) that is affected by the
+          phenotype.
+        range: AffectedEntity
+      qualifier:
+        description: >-
+          Additional ontological terms that refine the description of the phenotype.
+        range: PhenotypeQualifier
     slot_usage:
       phenotype_terms:
         values_from:
@@ -141,6 +239,11 @@ classes:
       - phenotype_term_curies
       - cross_reference_dto
       - negated
+    attributes:
+      affected_entity_dto:
+        range: AffectedEntityDTO
+      qualifier_dto:
+        range: PhenotypeQualifierDTO
 
   GenePhenotypeAnnotation:
     description: >-

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -102,10 +102,9 @@ classes:
           The biological process that is affected by a phenotype.
         range: GOTerm
         comments: >-
-          The model will accept any GO term in any branch. This should be further
-          constrained to the process branch only. In particular, should one wish
-          to indicate that a phenotype affects a cellular component, this should be
-          done using the location.cellular_component slot.
+          The model will accept any GO term in any branch, but should one wish to
+          indicate that a phenotype affects a cellular component, this should be
+          done using the location.cellular_component slot rather than here.
     comments: >-
       In the future, other slots may be added to allow referring to more kinds of
       entities, e.g. a slot with a CHEBITerm range to allow stating that a
@@ -157,10 +156,7 @@ classes:
           The main ontological term that refines the description of a phenotype.
         range: OntologicalTerm
         values_from:
-          - HP
-          - MP
           - WBPhenotype
-          - ZP
           - APO
           - FBcv
           - PATO
@@ -239,6 +235,7 @@ classes:
           - ZP
           - APO
           - FBcv
+          - XPO
         range: PhenotypeTerm
         examples:
           - value: HP:0002487

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -100,7 +100,16 @@ classes:
       process:
         description:
           The biological process that is affected by a phenotype.
-        range: GOTerm # FIXME: Should ideally be restricted to the "process" branch
+        range: GOTerm
+        comments: >-
+          The model will accept any GO term in any branch. This should be further
+          constrained to the process branch only. In particular, should one wish
+          to indicate that a phenotype affects a cellular component, this should be
+          done using the location.cellular_component slot.
+    comments: >-
+      In the future, other slots may be added to allow referring to more kinds of
+      entities, e.g. a slot with a CHEBITerm range to allow stating that a
+      phenotype affects a particular chemical entity.
     rules:
       - postconditions:
           any_of:
@@ -155,11 +164,25 @@ classes:
           - APO
           - FBcv
           - PATO
-        required: true
+      qualifier_tag:
+        description: >-
+          Similar to qualifier_term, but using a term from a vocabulary
+          rather than a dedicated ontology. Intended for "simple" qualifications
+          such as "abnormal", "ameliorated", "exacerbated", etc.
+        range: VocabularyTerm
       related_entity:
         description: >-
           An affected entity that further refines the description of a phenotype.
         range: AffectedEntity
+    rules:
+      - postconditions:
+          any_of:
+            - slot_conditions:
+                qualifier_term:
+                  required: true
+            - slot_conditions:
+                qualifier_tag:
+                  required: true
 
   PhenotypeQualifierDTO:
     is_a: AuditedObjectDTO
@@ -168,9 +191,19 @@ classes:
     attributes:
       qualifier_term_curie:
         range: string
-        required: true
+      qualifier_tag_name:
+        range: string
       related_entity:
         range: AffectedEntityDTO
+    rules:
+      - postconditions:
+          any_of:
+            - slot_conditions:
+                qualifier_term_curie:
+                  required: true
+            - slot_conditions:
+                qualifier_tag_name:
+                  required: true
 
   PhenotypeAnnotation:
     is_a: Annotation

--- a/model/schema/phenotypeAndDiseaseAnnotation.yaml
+++ b/model/schema/phenotypeAndDiseaseAnnotation.yaml
@@ -88,23 +88,10 @@ classes:
     is_a: AuditedObject
     description: >-
       An entity that is affected by a phenotype.
-    attributes:
-      location:
-        description: >-
-          The anatomical site that is affected by a phenotype.
-        range: AnatomicalSite
-      stage:
-        description: >-
-          The developmental stage that is affected by a phenotye.
-        range: TemporalContext
-      process:
-        description:
-          The biological process that is affected by a phenotype.
-        range: GOTerm
-        comments: >-
-          The model will accept any GO term in any branch, but should one wish to
-          indicate that a phenotype affects a cellular component, this should be
-          done using the location.cellular_component slot rather than here.
+    slots:
+      - phenotype_location
+      - phenotype_stage
+      - phenotype_process
     comments: >-
       In the future, other slots may be added to allow referring to more kinds of
       entities, e.g. a slot with a CHEBITerm range to allow stating that a
@@ -113,71 +100,52 @@ classes:
       - postconditions:
           any_of:
             - slot_conditions:
-                location:
+                phenotype_location:
                   required: true
             - slot_conditions:
-                stage:
+                phenotype_stage:
                   required: true
             - slot_conditions:
-                process:
+                phenotype_process:
                   required: true
 
   AffectedEntityDTO:
     is_a: AuditedObjectDTO
     description: >-
       Ingest class for an entity that is affected by a phenotype.
-    attributes:
-      location_dto:
-        range: AnatomicalSiteDTO
-      stage_dto:
-        range: TemporalContextDTO
-      process_curie:
-        range: string
+    slots:
+      - phenotype_location_dto
+      - phenotype_stage_dto
+      - phenotype_process_curie
     rules:
       - postconditions:
           any_of:
             - slot_conditions:
-                location_dto:
+                phenotype_location_dto:
                   required: true
             - slot_conditions:
-                stage_dto:
+                phenotype_stage_dto:
                   required: true
             - slot_conditions:
-                process_curie:
+                phenotype_process_curie:
                   required: true
 
   PhenotypeQualifier:
     is_a: AuditedObject
     description: >-
       Ontological terms that refine the description of a phenotype.
-    attributes:
-      qualifier_term:
-        description: >-
-          The main ontological term that refines the description of a phenotype.
-        range: OntologicalTerm
-        values_from:
-          - WBPhenotype
-          - APO
-          - FBcv
-          - PATO
-      qualifier_tag:
-        description: >-
-          Similar to qualifier_term, but using a term from a vocabulary
-          rather than a dedicated ontology. Intended for "simple" qualifications
-          such as "abnormal", "ameliorated", "exacerbated", etc.
-        range: VocabularyTerm
-      related_entity:
-        description: >-
-          An affected entity that further refines the description of a phenotype.
-        range: AffectedEntity
+    slots:
+      - phenotype_qualifier_term
+      - phenotype_qualifier_tag
+      - phenotype_related_entity
     rules:
       - postconditions:
           any_of:
             - slot_conditions:
-                qualifier_term:
+                phenotype_qualifier_term:
                   required: true
             - slot_conditions:
-                qualifier_tag:
+                phenotype_qualifier_tag:
                   required: true
 
   PhenotypeQualifierDTO:
@@ -189,8 +157,9 @@ classes:
         range: string
       qualifier_tag_name:
         range: string
-      related_entity:
+      related_entity_dto:
         range: AffectedEntityDTO
+        inlined: true
     rules:
       - postconditions:
           any_of:
@@ -272,8 +241,10 @@ classes:
     attributes:
       affected_entity_dto:
         range: AffectedEntityDTO
+        inlined: true
       qualifier_dto:
         range: PhenotypeQualifierDTO
+        inlined: true
 
   GenePhenotypeAnnotation:
     description: >-
@@ -979,7 +950,96 @@ slots:
     required: true
     domain: PhenotypeAnnotation
     range: BiologicalEntity
-  
+
+  phenotype_location:
+    description: >-
+      The anatomical site that is affected by a phenotype.
+    domain: AffectedEntity
+    range: AnatomicalSite
+
+  phenotype_location_dto:
+    description: >-
+      The anatomical site that is affected by a phenotype (submitted).
+    domain: AffectedEntityDTO
+    range: AnatomicalSiteDTO
+    inlined: true
+
+  phenotype_process:
+    description:
+      The biological process that is affected by a phenotype.
+    domain: AffectedEntity
+    range: GOTerm
+    comments: >-
+      The model will accept any GO term in any branch, but should one wish to
+      indicate that a phenotype affects a cellular component, this should be
+      done using the location.cellular_component slot rather than here.
+
+  phenotype_process_curie:
+    description:
+      The biological process that is affected by a phenotype (submitted).
+    domain: AffectedEntityDTO
+    range: string
+
+  phenotype_qualifier_term:
+    description: >-
+      The main ontological term that refines the description of a phenotype.
+    domain: PhenotypeQualifier
+    range: OntologyTerm
+    values_from:
+      - WBPhenotype
+      - APO
+      - FBcv
+      - PATO
+
+  phenotype_qualifier_term_curie:
+    domain: PhenotypeQualifierDTO
+    range: string
+
+  phenotype_qualifier_tag_name:
+    domain: PhenotypeQualifierDTO
+    range: string
+
+  phenotype_related_entity_dto:
+    domain: PhenotypeQualifierDTO
+    range: AffectedEntityDTO
+    inlined: true
+
+  phenotype_qualifier_tag:
+    description: >-
+      Similar to phenotype_qualifier_term, but using a term from a vocabulary
+      rather than a dedicated ontology. Intended for "simple" qualifications
+      such as "abnormal", "ameliorated", "exacerbated", etc.
+    domain: PhenotypeQualifier
+    range: VocabularyTerm
+
+  phenotype_related_entity:
+    description: >-
+      An affected entity that further refines the description of a phenotype.
+    domain: PhenotypeQualifier
+    range: AffectedEntity
+
+  phenotype_stage:
+    description: >-
+      The developmental stage that is affected by a phenotype.
+    domain: AffectedEntity
+    range: TemporalContext
+
+  phenotype_stage_dto:
+    description: >-
+      The developmental stage that is affected by a phenotype (submitted).
+    domain: AffectedEntityDTO
+    range: TemporalContextDTO
+    inlined: true
+
+
+
+  phenotype_statement:
+    description: >-
+      For MODs that curate to post-composed phenotype expressions composed
+      of ontology terms and other necessary information (e.g. vocabularies,
+      free text). This field captures the free text phenotype statement.
+    range: string
+
   phenotype_terms:
     description: >-
       The phenotype ontology term used to describe the phenotype of an organism
@@ -993,13 +1053,6 @@ slots:
       curie
     range: string
     multivalued: true
-
-  phenotype_statement:
-    description: >-
-      For MODs that curate to post-composed phenotype expressions composed
-      of ontology terms and other necessary information (e.g. vocabularies,
-      free text). This field captures the free text phenotype statement.
-    range: string
 
   sgd_strain_background:
     range: AffectedGenomicModel


### PR DESCRIPTION
This PR implements an alternative proposition to #307 (to be discussed in the upcoming Disease WG).

It amends the PhenotypeAnnotation class by adding two slots: `affected_entity` and `qualifier`.

`affected_entity` represents any entity that is affected by the phenotype that is being described. It can be an anatomical structure, a developmental stage, or a biological process. The slot has a dual purpose:

1. It can refine a phenotype that is otherwise described in `phenotype_terms`, by indicating which organ, stage, or process is affected by a phenotype.

2. It can describe a phenotype on its own (with `phenotype_terms` left empty), if the main characteristic of the phenotype is that it affects a particular organ, stage, or process (this is especially the case for some FlyBase-style phenotype annotations).

`qualifier` is used to further refine ("qualify") a phenotype that is otherwise described either by `phenotype_terms` or by `affected_entity`. It must contain at the very least an ontological term from either PATO or one of the phenotype ontologies (for the phenotype ontologies that have "modifier" terms). It may also contain a `related_entity`, which describes an additional entity (in the same sense as `affected_entity`) that is linked to the phenotype through the qualifier term. This slot is especially intended to allow representing ZFIN-style "Entity+Qualifier" (EQ) phenotype statements.