### PR TITLE
Reparent entity set classes from BiologicalEntity to SubmittedObject

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -21180,8 +21180,11 @@
                     "type": "string"
                 },
                 "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
+                    "description": "This slot is optional - it should not be used if multiple taxa are represented in the set.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
@@ -21194,7 +21197,6 @@
             "required": [
                 "full_name",
                 "symbol",
-                "taxon",
                 "data_provider",
                 "internal"
             ],
@@ -21379,8 +21381,11 @@
                     "type": "string"
                 },
                 "taxon_curie": {
-                    "description": "Curie of the NCBITaxonTerm representing the taxon from which the biological entity derives",
-                    "type": "string"
+                    "description": "This slot is optional - it should not be used if multiple taxa are represented in the set.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "updated_by_curie": {
                     "description": "Curie of the Person object representing the individual that updated the entity",
@@ -21393,7 +21398,6 @@
             "required": [
                 "full_name",
                 "symbol",
-                "taxon_curie",
                 "data_provider_dto",
                 "internal"
             ],
@@ -22610,10 +22614,6 @@
                         "null"
                     ]
                 },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
-                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -22623,7 +22623,6 @@
                 }
             },
             "required": [
-                "taxon",
                 "data_provider",
                 "internal"
             ],
@@ -22760,10 +22759,6 @@
                         "null"
                     ]
                 },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
-                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -22773,7 +22768,6 @@
                 }
             },
             "required": [
-                "taxon",
                 "data_provider",
                 "internal"
             ],
@@ -32593,10 +32587,6 @@
                         "null"
                     ]
                 },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
-                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -32606,7 +32596,6 @@
                 }
             },
             "required": [
-                "taxon",
                 "data_provider",
                 "internal"
             ],
@@ -33366,10 +33355,6 @@
                         "null"
                     ]
                 },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
-                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -33379,7 +33364,6 @@
                 }
             },
             "required": [
-                "taxon",
                 "data_provider",
                 "internal"
             ],
@@ -34427,10 +34411,6 @@
                         "null"
                     ]
                 },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
-                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -34440,7 +34420,6 @@
                 }
             },
             "required": [
-                "taxon",
                 "data_provider",
                 "internal"
             ],
@@ -41455,10 +41434,6 @@
                         "null"
                     ]
                 },
-                "taxon": {
-                    "description": "The taxon from which the biological entity derives.",
-                    "type": "string"
-                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -41468,7 +41443,6 @@
                 }
             },
             "required": [
-                "taxon",
                 "data_provider",
                 "internal"
             ],

--- a/model/schema/biologicalEntitySet.yaml
+++ b/model/schema/biologicalEntitySet.yaml
@@ -53,7 +53,7 @@ classes:
     description: >-
       A gene cluster is a set of genes which have a biological significance, and
       which are probably clustered together on the genome, like histones and miRNAs
-    is_a: BiologicalEntity
+    is_a: SubmittedObject
     slots:
       - genes
       - related_note
@@ -61,7 +61,7 @@ classes:
   GeneCollection:
     description: >-
       A gene collection is a set of genes which have been grouped based on experimental evidence, for example a set of interacting genes, genes in expression cluster, or a set of ChIP binding peaks
-    is_a: BiologicalEntity
+    is_a: SubmittedObject
     slots:
       - genes
       - related_note
@@ -85,7 +85,7 @@ classes:
       The DNA region of a group of adjacent genes whose transcription is
       coordinated on one or several mutually overlapping transcription
       units transcribed in the same direction and sharing at least one gene.
-    is_a: BiologicalEntity
+    is_a: SubmittedObject
     slots:
       - genes
       - related_note
@@ -97,15 +97,16 @@ classes:
     description: >-
       XenBase-specific. A set of three genes from X. tropicalis and X. laevis (S and L forms)
       representing a single unigene.
-    is_a: BiologicalEntity
+    is_a: SubmittedObject
     slots:
       - genes
 
   FunctionalGeneSet:
     description: >-
       Families and groups of genes related by sequence and/or function.
-    is_a: BiologicalEntity
+    is_a: SubmittedObject
     slots:
+      - taxon
       - full_name
       - symbol
       - set_synonyms
@@ -119,13 +120,17 @@ classes:
       - secondary_identifiers
       - gene_functional_gene_set_associations
     slot_usage:
+      taxon:
+        description: >-
+          This slot is optional - it should not be used if multiple taxa are
+          represented in the set.
       full_name:
         required: true
       symbol:
         required: true
 
   Pathway:
-    is_a: BiologicalEntity # gets all the audit fields from its parent AuditedObject
+    is_a: SubmittedObject
     exact_mappings:
       - biolink:Pathway
       - PW:0000001
@@ -143,7 +148,7 @@ classes:
       - KEGG.PATHWAY
 
   ProteinComplex:
-    is_a: BiologicalEntity
+    is_a: SubmittedObject
     slots:
       - proteins
 
@@ -187,11 +192,12 @@ classes:
         required: true
 
   FunctionalGeneSetDTO:
-    is_a: BiologicalEntityDTO
+    is_a: SubmittedObjectDTO
     description: >-
       Ingest class for functional gene sets (families and groups of genes
       related by sequence and/or function).
     slots:
+      - taxon_curie
       - full_name
       - symbol
       - set_synonym_dtos
@@ -204,6 +210,10 @@ classes:
       - related_resources
       - secondary_identifiers
     slot_usage:
+      taxon_curie:
+        description: >-
+          This slot is optional - it should not be used if multiple taxa are
+          represented in the set.
       full_name:
         required: true
       symbol:

--- a/model/schema/biologicalEntitySet.yaml
+++ b/model/schema/biologicalEntitySet.yaml
@@ -124,6 +124,7 @@ classes:
         description: >-
           This slot is optional - it should not be used if multiple taxa are
           represented in the set.
+        required: false
       full_name:
         required: true
       symbol:
@@ -214,6 +215,7 @@ classes:
         description: >-
           This slot is optional - it should not be used if multiple taxa are
           represented in the set.
+        required: false
       full_name:
         required: true
       symbol:


### PR DESCRIPTION
## Summary
- Reparent **GeneCluster**, **GeneCollection**, **Operon**, **UniGeneSet**, **FunctionalGeneSet**, **Pathway**, and **ProteinComplex** from `BiologicalEntity` to `SubmittedObject` — these represent sets/groups that may span multiple species and should not require a single taxon
- Reparent **FunctionalGeneSetDTO** from `BiologicalEntityDTO` to `SubmittedObjectDTO`
- Add `taxon`/`taxon_curie` as an **optional** slot on `FunctionalGeneSet`/`FunctionalGeneSetDTO` with description: "This slot is optional - it should not be used if multiple taxa are represented in the set."

## Test plan
- [ ] CI regenerates artifacts and passes validation
- [ ] Verify existing FunctionalGeneSet test data still validates
- [ ] Verify FunctionalGeneSet data without taxon now validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)