### PR TITLE
Fix functional gene set test

### DIFF
--- a/test/data/functional_gene_set_ingest_test.json
+++ b/test/data/functional_gene_set_ingest_test.json
@@ -196,7 +196,7 @@
           "display_name": "Human Wnt family (HGNC)",
           "internal": false
         }
-      ],
+      ]
     }
   ],
   "gene_functional_gene_set_association_ingest_set": [


### PR DESCRIPTION
@sjm41 Super simple fix needed on the functional gene set test JSON file. There was an unexpected trailing comma that I removed.