### PR TITLE
Add optional is_aberration and is_balancer flags to Allele

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -3309,7 +3309,7 @@
                     "type": "boolean"
                 },
                 "is_aberration": {
-                    "description": "Indicates whether the allele is a chromosomal aberration (a multi-gene allele), as opposed to a traditional single-gene allele.",
+                    "description": "Indicates whether the allele is a chromosomal aberration, defined (per SO:1000183 - chromosome_structure_variation) as an alteration of the genome that leads to a change in the structure or number of one or more chromosomes.",
                     "type": [
                         "boolean",
                         "null"
@@ -4207,7 +4207,7 @@
                     "type": "boolean"
                 },
                 "is_aberration": {
-                    "description": "Indicates whether the allele is a chromosomal aberration (a multi-gene allele), as opposed to a traditional single-gene allele.",
+                    "description": "Indicates whether the allele is a chromosomal aberration, defined (per SO:1000183 - chromosome_structure_variation) as an alteration of the genome that leads to a change in the structure or number of one or more chromosomes.",
                     "type": [
                         "boolean",
                         "null"

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -3308,6 +3308,20 @@
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
                 },
+                "is_aberration": {
+                    "description": "Indicates whether the allele is a chromosomal aberration (a multi-gene allele), as opposed to a traditional single-gene allele.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "is_balancer": {
+                    "description": "Indicates whether the allele is a balancer: a chromosomal rearrangement that suppresses recombination over a region of one or more chromosomes. Balancers are a subtype of aberration, so this is only applicable to alleles for which is_aberration is true.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "is_extinct": {
                     "description": "Does the allele still exist in a population somewhere?",
                     "type": [
@@ -4191,6 +4205,20 @@
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
+                },
+                "is_aberration": {
+                    "description": "Indicates whether the allele is a chromosomal aberration (a multi-gene allele), as opposed to a traditional single-gene allele.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "is_balancer": {
+                    "description": "Indicates whether the allele is a balancer: a chromosomal rearrangement that suppresses recombination over a region of one or more chromosomes. Balancers are a subtype of aberration, so this is only applicable to alleles for which is_aberration is true.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 },
                 "is_extinct": {
                     "description": "Does the allele still exist in a population somewhere?",

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -61,6 +61,8 @@ classes:
       - is_extinct
       - is_extrachromosomal
       - is_integrated
+      - is_aberration
+      - is_balancer
       - transgene_chromosome_location
       - allele_mutation_types
       - allele_inheritance_modes
@@ -83,8 +85,6 @@ classes:
     exact_mappings:
       - SO:0001023
     slot_usage:
-      aberration: # This slot is no longer declared in the Allele class; is this covered by something else? [CG]
-        notes: specific to FB
       allele_symbol:
         required: true
       laboratory_of_origin:
@@ -92,6 +92,10 @@ classes:
       is_extrachromosomal:
         required: false
       is_integrated:
+        required: false
+      is_aberration:
+        required: false
+      is_balancer:
         required: false
       related_notes:
         notes: note_type from VocabularyTermSet 'Allele Note Type'
@@ -109,6 +113,8 @@ classes:
       - is_extinct
       - is_extrachromosomal
       - is_integrated
+      - is_aberration
+      - is_balancer
       - transgene_chromosome_location_name
       - allele_mutation_type_dtos
       - allele_inheritance_mode_dtos
@@ -675,14 +681,6 @@ classes:
 ## ------------
 
 slots:
-  # This slot is currently not being used 2022-12-20; should it be? [CG]
-  aberration:
-    description: >-
-      Associated deficiency (etc.) whose breakpoint causes
-      the mutation
-    domain: Allele
-    range: string
-
   allele_allele_associations:
     domain: Allele
     range: AlleleAlleleAssociation
@@ -1008,6 +1006,22 @@ slots:
       The name of the irradiation used to generate the mutation through mutagenesis
     domain: GenerationMethodDTO
     range: string # CV 'Irradiation Mutagen'
+
+  is_aberration:
+    description: >-
+      Indicates whether the allele is a chromosomal aberration (a multi-gene
+      allele), as opposed to a traditional single-gene allele.
+    domain: Allele
+    range: boolean
+
+  is_balancer:
+    description: >-
+      Indicates whether the allele is a balancer: a chromosomal rearrangement
+      that suppresses recombination over a region of one or more chromosomes.
+      Balancers are a subtype of aberration, so this is only applicable to
+      alleles for which is_aberration is true.
+    domain: Allele
+    range: boolean
 
   is_extinct:
     description: >-

--- a/model/schema/allele.yaml
+++ b/model/schema/allele.yaml
@@ -1009,8 +1009,10 @@ slots:
 
   is_aberration:
     description: >-
-      Indicates whether the allele is a chromosomal aberration (a multi-gene
-      allele), as opposed to a traditional single-gene allele.
+      Indicates whether the allele is a chromosomal aberration, defined
+      (per SO:1000183 - chromosome_structure_variation) as an alteration of the
+      genome that leads to a change in the structure or number of one or more
+      chromosomes.
     domain: Allele
     range: boolean
 


### PR DESCRIPTION
## Summary

FlyBase makes a clear distinction between traditional single-gene alleles and chromosomal aberrations (multi-gene alleles) — handling them as separate data classes (FBal vs FBab) — and balancers are a subtype of aberration. This adds two optional booleans to `Allele`/`AlleleDTO` to capture that distinction within the Alliance single `Allele` class:

- **`is_aberration`** — indicates the allele is a chromosomal aberration (multi-gene allele) rather than a traditional single-gene allele.
- **`is_balancer`** — indicates the allele is a balancer (a recombination-suppressing chromosomal rearrangement). Balancers are a subtype of aberration, so this is only applicable to alleles for which `is_aberration` is true (documented in the slot description; not schema-enforced).

Both follow the existing `is_extinct` / `is_extrachromosomal` / `is_integrated` pattern — plain optional booleans reused directly in the DTO.

## Also

Removes the dead `aberration` `slot_usage` entry (flagged by `[CG]` as no longer declared) and its unused standalone slot definition, which `is_aberration` supersedes. Both were already absent from the generated artifacts.

## Notes

- No LinkML `rule` enforcing balancer ⟹ aberration (considered, deliberately left out).
- `generated/` artifacts will be regenerated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
