### PR TITLE
SCRUM-6204: Add resource_descriptor_page slot to ExternalDatabaseRefe…

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -16597,7 +16597,8 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "description": "ResourceDescriptorPage providing the URL template used to render a linkout to the referenced external identifier."
                 },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
@@ -20664,6 +20665,17 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "resource_descriptor_page": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ResourceDescriptorPage"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "ResourceDescriptorPage providing the URL template used to render a linkout to the referenced external identifier."
                 },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -1614,7 +1614,9 @@ slots:
     required: true
 
   resource_descriptor_page:
-    domain: CrossReference
+    description: >-
+      ResourceDescriptorPage providing the URL template used to render a
+      linkout to the referenced external identifier.
     range: ResourceDescriptorPage
 
   transcript_genomic_location_associations:

--- a/model/schema/reference.yaml
+++ b/model/schema/reference.yaml
@@ -55,6 +55,8 @@ classes:
     is_a: InformationContentEntity
     description: >-
       A reference to an entity in an external database
+    slots:
+      - resource_descriptor_page
 
   Reference:
     is_a: InformationContentEntity


### PR DESCRIPTION
…rence

Preparation for upcoming indexer and UI work that will consume linkout metadata for OMIM (MIM:xxx) and Orphanet (ORPHA:xxx) references persisted as ExternalDatabaseReference evidenceItems. Landing the slot first ensures those consumers have populated data when they ship. Domain constraint dropped since ExternalDatabaseReference and CrossReference share no common ancestor below Thing.