### PR TITLE
KANBAN-820 Add evidence to transgenic tool uses

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -13993,7 +13993,7 @@
                     ]
                 },
                 "uses": {
-                    "description": "Holds between a TransgenicTool and a list of FBcv terms with namespace 'experimental_tool_descriptor'",
+                    "description": "A list of FBcv terms with namespace 'experimental_tool_descriptor'.",
                     "items": {
                         "type": "string"
                     },
@@ -14080,7 +14080,7 @@
                     ]
                 },
                 "use_curies": {
-                    "description": "Holds between a TransgenicTool and a list of curies of FBcv terms with namespace 'experimental_tool_descriptor'",
+                    "description": "A list of curies for FBcv terms with namespace 'experimental_tool_descriptor'.",
                     "items": {
                         "type": "string"
                     },
@@ -41265,6 +41265,16 @@
                         "null"
                     ]
                 },
+                "transgenic_tool_uses": {
+                    "description": "Holds between a TransgenicTool and a list of uses.",
+                    "items": {
+                        "$ref": "#/$defs/TransgenicToolUseSlotAnnotation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "unique_id": {
                     "description": "A non-curie unique identifier for a thing.",
                     "type": [
@@ -41276,16 +41286,6 @@
                     "description": "The individual that last modified the entity.",
                     "type": [
                         "string",
-                        "null"
-                    ]
-                },
-                "uses": {
-                    "description": "Holds between a TransgenicTool and a list of FBcv terms with namespace 'experimental_tool_descriptor'",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
                         "null"
                     ]
                 }
@@ -41439,20 +41439,20 @@
                         "null"
                     ]
                 },
+                "transgenic_tool_use_dtos": {
+                    "description": "Holds between a TransgenicTool and a list of uses.",
+                    "items": {
+                        "$ref": "#/$defs/TransgenicToolUseSlotAnnotationDTO"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "updated_by_curie": {
                     "description": "Curie of the Person object representing the individual that updated the entity",
                     "type": [
                         "string",
-                        "null"
-                    ]
-                },
-                "use_curies": {
-                    "description": "Holds between a TransgenicTool and a list of curies of FBcv terms with namespace 'experimental_tool_descriptor'",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
                         "null"
                     ]
                 }
@@ -41970,6 +41970,182 @@
                 "internal"
             ],
             "title": "TransgenicToolTransgenicToolAssociationDTO",
+            "type": "object"
+        },
+        "TransgenicToolUseSlotAnnotation": {
+            "additionalProperties": false,
+            "description": "A slot annotation to capture the use(s) of a particular TransgenicTool with associated evidence.",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "evidence": {
+                    "description": "The evidence that supports some assertion.",
+                    "items": {
+                        "$ref": "#/$defs/InformationContentEntity"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "single_transgenic_tool": {
+                    "$ref": "#/$defs/TransgenicTool"
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uses": {
+                    "description": "A list of FBcv terms with namespace 'experimental_tool_descriptor'.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "single_transgenic_tool",
+                "uses",
+                "internal"
+            ],
+            "title": "TransgenicToolUseSlotAnnotation",
+            "type": "object"
+        },
+        "TransgenicToolUseSlotAnnotationDTO": {
+            "additionalProperties": false,
+            "description": "Ingest class for a slot annotation to capture the use(s) of a particular TransgenicTool with associated evidence.",
+            "properties": {
+                "created_by_curie": {
+                    "description": "Curie of the Person object representing the individual that created the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "evidence_curies": {
+                    "description": "Curies of InformationContentEntity objects given as evidence",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "updated_by_curie": {
+                    "description": "Curie of the Person object representing the individual that updated the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "use_curies": {
+                    "description": "A list of curies for FBcv terms with namespace 'experimental_tool_descriptor'.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "use_curies",
+                "internal"
+            ],
+            "title": "TransgenicToolUseSlotAnnotationDTO",
             "type": "object"
         },
         "UBERONTerm": {

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -596,7 +596,7 @@ classes:
       - transgenic_tool_symbol
       - transgenic_tool_full_name
       - transgenic_tool_synonyms
-      - uses
+      - transgenic_tool_uses
       - references
 
   TransgenicToolDTO:
@@ -610,8 +610,32 @@ classes:
       - transgenic_tool_symbol_dto
       - transgenic_tool_full_name_dto
       - transgenic_tool_synonym_dtos
-      - use_curies
+      - transgenic_tool_use_dtos
       - reference_curies
+
+  TransgenicToolUseSlotAnnotation:
+    is_a: SlotAnnotation
+    description: >-
+      A slot annotation to capture the use(s) of a particular TransgenicTool with associated evidence.
+    slots:
+      - single_transgenic_tool
+      - uses
+    slot_usage:
+      single_transgenic_tool:
+        required: true
+      uses:
+        required: true
+
+  TransgenicToolUseSlotAnnotationDTO:
+    is_a: SlotAnnotationDTO
+    description: >-
+      Ingest class for a slot annotation to capture the use(s) of a particular TransgenicTool with
+      associated evidence.
+    slots:
+      - use_curies
+    slot_usage:
+      use_curies:
+        required: true
 
   TransgenicToolSymbolSlotAnnotation:
     description: >-
@@ -1080,6 +1104,21 @@ slots:
     description: Holds between a TransgenicTool and a list of synonyms.
     domain: TransgenicToolDTO
     range: NameSlotAnnotationDTO
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+  transgenic_tool_uses:
+    description: Holds between a TransgenicTool and a list of uses.
+    domain: TransgenicTool
+    required: false
+    multivalued: true
+    range: TransgenicToolUseSlotAnnotation
+
+  transgenic_tool_use_dtos:
+    description: Holds between a TransgenicTool and a list of uses.
+    domain: TransgenicToolDTO
+    range: TransgenicToolUseSlotAnnotationDTO
     multivalued: true
     inlined: true
     inlined_as_list: true

--- a/model/schema/reagent.yaml
+++ b/model/schema/reagent.yaml
@@ -1125,15 +1125,13 @@ slots:
 
   uses:
     description: >-
-      Holds between a TransgenicTool and a list of FBcv terms with namespace
-      'experimental_tool_descriptor'
+      A list of FBcv terms with namespace 'experimental_tool_descriptor'.
     range: FBCVTerm
     multivalued: true
 
   use_curies:
     description: >-
-      Holds between a TransgenicTool and a list of curies of FBcv terms with namespace
-      'experimental_tool_descriptor'
+      A list of curies for FBcv terms with namespace 'experimental_tool_descriptor'.
     range: string
     multivalued: true
 

--- a/test/data/transgenic_tool_test.json
+++ b/test/data/transgenic_tool_test.json
@@ -86,9 +86,17 @@
           "internal": true
         }
       ],
-      "use_curies": [
-        "FBcv:0005056",
-        "FBcv:0009038"
+      "transgenic_tool_use_dtos": [
+        {
+          "use_curies": [
+            "FBcv:0005056",
+            "FBcv:0009038"
+          ],
+          "evidence_curies": [
+            "PMID:01231002"
+          ],
+          "internal": false
+        }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- model TransgenicTool uses through TransgenicToolUseSlotAnnotation
- add the matching ingest DTO and inlined transgenic_tool_use_dtos slot
- update the transgenic tool fixture to associate a PMID with its uses

## Validation
- `make install` — passed
- `make clean` — passed
- `make all` — passed; generated JSON Schema matches the artifact committed by CI
- `make test` — passed
- full `make test-jsonschema` rerun — passed with exit code 0; all registered valid fixtures reported no issues
- GitHub Actions `Test PRs` matrix — passed on Python 3.9, 3.10, and 3.11
- GitHub Actions artifact regeneration — passed and committed the generated JSON Schema

No current submitter uses the previous flat `use_curies` field, so the ingest shape change has no compatibility impact.

[Jira: KANBAN-820](https://agr-jira.atlassian.net/browse/KANBAN-820)