### PR TITLE
SCRUM-6283 Add ChromosomeAccession class

### DIFF
--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -14426,6 +14426,94 @@
             "title": "Chromosome",
             "type": "object"
         },
+        "ChromosomeAccession": {
+            "additionalProperties": false,
+            "description": "A mapping of a chromosome name to its RefSeq accession within a specific genome assembly. Holds the reference data formerly hard-coded in the ChromosomeAccessionEnum so that new genome assemblies can be added via data load rather than a code change.",
+            "properties": {
+                "accession": {
+                    "description": "The RefSeq accession of the chromosome sequence (e.g. \"RefSeq:NC_002333.2\").",
+                    "type": "string"
+                },
+                "assembly_identifier": {
+                    "description": "The identifier of the genome assembly the accession belongs to (e.g. \"GRCz11\").",
+                    "type": "string"
+                },
+                "chromosome_name": {
+                    "description": "The chromosome name within the genome assembly (e.g. \"2L\", \"X\", \"MT\").",
+                    "type": "string"
+                },
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "display_order": {
+                    "description": "Ordering used to resolve an accession shared across assemblies to the earlier-declared assembly first, preserving the former enum's lookup behaviour.",
+                    "type": "integer"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "chromosome_name",
+                "accession",
+                "assembly_identifier",
+                "display_order",
+                "internal"
+            ],
+            "title": "ChromosomeAccession",
+            "type": "object"
+        },
         "ChromosomeDTO": {
             "additionalProperties": false,
             "description": "Ingest class for chromosomes",

--- a/model/schema/core.yaml
+++ b/model/schema/core.yaml
@@ -581,6 +581,36 @@ classes:
       name:
         required: true
 
+  ChromosomeAccession:
+    is_a: AuditedObject
+    description: >-
+      A mapping of a chromosome name to its RefSeq accession within a specific
+      genome assembly. Holds the reference data formerly hard-coded in the
+      ChromosomeAccessionEnum so that new genome assemblies can be added via data
+      load rather than a code change.
+    attributes:
+      chromosome_name:
+        range: string
+        required: true
+        description: >-
+          The chromosome name within the genome assembly (e.g. "2L", "X", "MT").
+      accession:
+        range: string
+        required: true
+        description: >-
+          The RefSeq accession of the chromosome sequence (e.g. "RefSeq:NC_002333.2").
+      assembly_identifier:
+        range: string
+        required: true
+        description: >-
+          The identifier of the genome assembly the accession belongs to (e.g. "GRCz11").
+      display_order:
+        range: integer
+        required: true
+        description: >-
+          Ordering used to resolve an accession shared across assemblies to the
+          earlier-declared assembly first, preserving the former enum's lookup behaviour.
+
   GenomeAssembly:
     is_a: BiologicalEntity
     description: >-


### PR DESCRIPTION
## Summary
Adds a `ChromosomeAccession` class to `core.yaml`, modelling the chromosome-name / RefSeq-accession / genome-assembly reference data that is currently hard-coded in the `ChromosomeAccessionEnum` in `agr_curation`. Moving this into the schema (and a DB table on the app side) lets new genome assemblies be added via data load instead of a code change.

Companion to agr_curation PR #2869 (SCRUM-6283), which adds the JPA entity, DAO, service, and Flyway-seeded table.

## Details
- `is_a: AuditedObject`, placed alongside `Chromosome` / `AssemblyComponent` in `core.yaml`.
- Fields defined as inline `attributes` (all `required`): `chromosome_name`, `accession`, `assembly_identifier`, `display_order`.
- `display_order` preserves the enum's original declaration order so accessions shared across assemblies (e.g. `RefSeq:NC_002333.2` for GRCz11 & GRCz12tu) resolve to the earlier-declared assembly, matching prior behaviour.
- **No `...DTO` class** — this is internal reference data seeded via migration with no ingest path (mirrors `OntologyTermClosure`).

## Notes
- No `generated/` edits (CI regenerates artifacts).
- No new test data added: this is a new class within an existing domain (`core.yaml`), not a new domain, and it has no ingest JSON-schema surface to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)