### PR TITLE
Add BiologicalEntitySet parent and expand Pathway model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ SCHEMA_TEST_EXAMPLES := \
 	genome_assembly_test \
 	high_throughput_expression_test \
 	ontology_closure_test \
+	pathway_ingest_test \
 	phenotype_agm_test \
 	phenotype_allele_test \
 	phenotype_gene_test \

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -35666,12 +35666,22 @@
         },
         "ProteinComplex": {
             "additionalProperties": false,
-            "description": "",
+            "description": "A set of proteins that assemble into a stable complex to carry out a biological function.",
             "properties": {
                 "created_by": {
                     "description": "The individual that created the entity.",
                     "type": [
                         "string",
+                        "null"
+                    ]
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": [
+                        "array",
                         "null"
                     ]
                 },
@@ -35729,6 +35739,10 @@
                         "null"
                     ]
                 },
+                "full_name": {
+                    "description": "The full name of the entity",
+                    "type": "string"
+                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
@@ -35744,6 +35758,16 @@
                     "description": "Entity is no longer current.",
                     "type": [
                         "boolean",
+                        "null"
+                    ]
+                },
+                "parent_sets": {
+                    "description": "Parent set(s) of which this set is a subset.",
+                    "items": {
+                        "$ref": "#/$defs/ProteinComplex"
+                    },
+                    "type": [
+                        "array",
                         "null"
                     ]
                 },
@@ -35773,6 +35797,79 @@
                         "null"
                     ]
                 },
+                "related_sets": {
+                    "description": "Other related sets.",
+                    "items": {
+                        "$ref": "#/$defs/BiologicalEntitySet"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_bp_terms": {
+                    "description": "Key Gene Ontology Biological Process terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_cc_terms": {
+                    "description": "Key Gene Ontology Cellular Component terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_mf_terms": {
+                    "description": "Key Gene Ontology Molecular Function terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_synonyms": {
+                    "description": "Synonyms for the biological entity set.",
+                    "items": {
+                        "$ref": "#/$defs/BiologicalEntitySetSynonymSlotAnnotation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "symbol": {
+                    "description": "The free text symbol (human-readable) for an entity or record",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "taxon": {
+                    "description": "This slot is optional - it should not be used if multiple taxa are represented in the set.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -35782,6 +35879,7 @@
                 }
             },
             "required": [
+                "full_name",
                 "data_provider",
                 "internal"
             ],

--- a/generated/jsonschema/allianceModel.schema.json
+++ b/generated/jsonschema/allianceModel.schema.json
@@ -10707,6 +10707,117 @@
             "title": "BioSampleGenomicInformationDTO",
             "type": "object"
         },
+        "BiologicalEntitySetSynonymSlotAnnotation": {
+            "additionalProperties": false,
+            "description": "All aliases (non-preferred names) for the biological entity set. Acceptable synonym types are full_name, nomenclature_symbol, and unspecified",
+            "properties": {
+                "created_by": {
+                    "description": "The individual that created the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "display_text": {
+                    "description": "A version of a synonym string for display. Any UTF8 character is permitted.",
+                    "type": "string"
+                },
+                "evidence": {
+                    "description": "The evidence that supports some assertion.",
+                    "items": {
+                        "$ref": "#/$defs/InformationContentEntity"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "format_text": {
+                    "description": "A version of a synonym string using only ASCII characters, which is easier to type (for searches), print and parse. For example, Greek characters are transliterated.",
+                    "type": "string"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "name_type": {
+                    "description": "The type of name: e.g., symbol, full_name, systematic_name, etc.",
+                    "type": "string"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "single_biological_entity_set": {
+                    "$ref": "#/$defs/BiologicalEntitySet"
+                },
+                "synonym_scope": {
+                    "description": "the scope of the synonym - permissible values are narrow / broad / related / exact",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "synonym_url": {
+                    "description": "URL for a synonym: e.g., NCBI URL for the NCBI synonym of an object.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "updated_by": {
+                    "description": "The individual that last modified the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "single_biological_entity_set",
+                "name_type",
+                "format_text",
+                "display_text",
+                "internal"
+            ],
+            "title": "BiologicalEntitySetSynonymSlotAnnotation",
+            "type": "object"
+        },
         "BulkFMSLoad": {
             "additionalProperties": false,
             "description": "This bulk load automatically pulls files from the BulkFMSLoad",
@@ -21542,7 +21653,7 @@
                     ]
                 },
                 "parent_sets": {
-                    "description": "Parent functional gene set(s) of which this set is a subset.",
+                    "description": "Parent set(s) of which this set is a subset.",
                     "items": {
                         "$ref": "#/$defs/FunctionalGeneSet"
                     },
@@ -21569,9 +21680,9 @@
                     ]
                 },
                 "related_sets": {
-                    "description": "Other related functional gene sets.",
+                    "description": "Other related sets.",
                     "items": {
-                        "$ref": "#/$defs/FunctionalGeneSet"
+                        "$ref": "#/$defs/BiologicalEntitySet"
                     },
                     "type": [
                         "array",
@@ -21588,7 +21699,7 @@
                     ]
                 },
                 "set_go_bp_terms": {
-                    "description": "Key Gene Ontology Biological Process terms associated with this functional gene set.",
+                    "description": "Key Gene Ontology Biological Process terms associated with this set.",
                     "items": {
                         "type": "string"
                     },
@@ -21598,7 +21709,7 @@
                     ]
                 },
                 "set_go_cc_terms": {
-                    "description": "Key Gene Ontology Cellular Component terms associated with this functional gene set.",
+                    "description": "Key Gene Ontology Cellular Component terms associated with this set.",
                     "items": {
                         "type": "string"
                     },
@@ -21608,7 +21719,7 @@
                     ]
                 },
                 "set_go_mf_terms": {
-                    "description": "Key Gene Ontology Molecular Function terms associated with this functional gene set.",
+                    "description": "Key Gene Ontology Molecular Function terms associated with this set.",
                     "items": {
                         "type": "string"
                     },
@@ -21618,9 +21729,9 @@
                     ]
                 },
                 "set_synonyms": {
-                    "description": "Synonyms for the functional gene set.",
+                    "description": "Synonyms for the biological entity set.",
                     "items": {
-                        "$ref": "#/$defs/FunctionalGeneSetSynonymSlotAnnotation"
+                        "$ref": "#/$defs/BiologicalEntitySetSynonymSlotAnnotation"
                     },
                     "type": [
                         "array",
@@ -21629,7 +21740,10 @@
                 },
                 "symbol": {
                     "description": "The free text symbol (human-readable) for an entity or record",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "taxon": {
                     "description": "This slot is optional - it should not be used if multiple taxa are represented in the set.",
@@ -21648,7 +21762,6 @@
             },
             "required": [
                 "full_name",
-                "symbol",
                 "data_provider",
                 "internal"
             ],
@@ -21743,7 +21856,7 @@
                     ]
                 },
                 "parent_set_identifiers": {
-                    "description": "Identifiers (curie/primary_external_id/mod_internal_id) of parent functional gene set(s) of which this set is a subset.",
+                    "description": "Identifiers (curie/primary_external_id/mod_internal_id) of parent set(s) of which this set is a subset.",
                     "items": {
                         "type": "string"
                     },
@@ -21760,7 +21873,7 @@
                     ]
                 },
                 "related_set_identifiers": {
-                    "description": "Identifiers (curie/primary_external_id/mod_internal_id) of other related functional gene sets.",
+                    "description": "Identifiers (curie/primary_external_id/mod_internal_id) of other related sets.",
                     "items": {
                         "type": "string"
                     },
@@ -21779,7 +21892,7 @@
                     ]
                 },
                 "set_go_bp_term_curies": {
-                    "description": "CURIEs of key Gene Ontology Biological Process terms associated with this functional gene set.",
+                    "description": "CURIEs of key Gene Ontology Biological Process terms associated with this set.",
                     "items": {
                         "type": "string"
                     },
@@ -21789,7 +21902,7 @@
                     ]
                 },
                 "set_go_cc_term_curies": {
-                    "description": "CURIEs of key Gene Ontology Cellular Component terms associated with this functional gene set.",
+                    "description": "CURIEs of key Gene Ontology Cellular Component terms associated with this set.",
                     "items": {
                         "type": "string"
                     },
@@ -21799,7 +21912,7 @@
                     ]
                 },
                 "set_go_mf_term_curies": {
-                    "description": "CURIEs of key Gene Ontology Molecular Function terms associated with this functional gene set.",
+                    "description": "CURIEs of key Gene Ontology Molecular Function terms associated with this set.",
                     "items": {
                         "type": "string"
                     },
@@ -21809,7 +21922,7 @@
                     ]
                 },
                 "set_synonym_dtos": {
-                    "description": "Synonyms for the functional gene set.",
+                    "description": "Synonyms for the biological entity set.",
                     "items": {
                         "$ref": "#/$defs/NameSlotAnnotationDTO"
                     },
@@ -21820,7 +21933,10 @@
                 },
                 "symbol": {
                     "description": "The free text symbol (human-readable) for an entity or record",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "taxon_curie": {
                     "description": "This slot is optional - it should not be used if multiple taxa are represented in the set.",
@@ -21839,122 +21955,10 @@
             },
             "required": [
                 "full_name",
-                "symbol",
                 "data_provider_dto",
                 "internal"
             ],
             "title": "FunctionalGeneSetDTO",
-            "type": "object"
-        },
-        "FunctionalGeneSetSynonymSlotAnnotation": {
-            "additionalProperties": false,
-            "description": "All aliases (non-preferred names) for the functional gene set. Acceptable synonym types are full_name, nomenclature_symbol, and unspecified",
-            "properties": {
-                "created_by": {
-                    "description": "The individual that created the entity.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "date_created": {
-                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
-                    "format": "date-time",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "date_updated": {
-                    "description": "Date on which an entity was last modified.",
-                    "format": "date-time",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "db_date_created": {
-                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
-                    "format": "date-time",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "db_date_updated": {
-                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
-                    "format": "date-time",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "display_text": {
-                    "description": "A version of a synonym string for display. Any UTF8 character is permitted.",
-                    "type": "string"
-                },
-                "evidence": {
-                    "description": "The evidence that supports some assertion.",
-                    "items": {
-                        "$ref": "#/$defs/InformationContentEntity"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
-                "format_text": {
-                    "description": "A version of a synonym string using only ASCII characters, which is easier to type (for searches), print and parse. For example, Greek characters are transliterated.",
-                    "type": "string"
-                },
-                "internal": {
-                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
-                    "type": "boolean"
-                },
-                "name_type": {
-                    "description": "The type of name: e.g., symbol, full_name, systematic_name, etc.",
-                    "type": "string"
-                },
-                "obsolete": {
-                    "description": "Entity is no longer current.",
-                    "type": [
-                        "boolean",
-                        "null"
-                    ]
-                },
-                "single_functional_gene_set": {
-                    "$ref": "#/$defs/FunctionalGeneSet"
-                },
-                "synonym_scope": {
-                    "description": "the scope of the synonym - permissible values are narrow / broad / related / exact",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "synonym_url": {
-                    "description": "URL for a synonym: e.g., NCBI URL for the NCBI synonym of an object.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "updated_by": {
-                    "description": "The individual that last modified the entity.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "required": [
-                "single_functional_gene_set",
-                "name_type",
-                "format_text",
-                "display_text",
-                "internal"
-            ],
-            "title": "FunctionalGeneSetSynonymSlotAnnotation",
             "type": "object"
         },
         "GENOTerm": {
@@ -26025,7 +26029,7 @@
         },
         "GenePathwayAssociation": {
             "additionalProperties": false,
-            "description": "",
+            "description": "Association between a gene and a pathway, with supporting references that demonstrate or state the gene's participation in the pathway.",
             "properties": {
                 "created_by": {
                     "description": "The individual that created the entity.",
@@ -26113,6 +26117,99 @@
                 "internal"
             ],
             "title": "GenePathwayAssociation",
+            "type": "object"
+        },
+        "GenePathwayAssociationDTO": {
+            "additionalProperties": false,
+            "description": "Ingest class for association between a gene and a pathway, with supporting references that demonstrate or state the gene's participation in the pathway.",
+            "properties": {
+                "created_by_curie": {
+                    "description": "Curie of the Person object representing the individual that created the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "evidence_curies": {
+                    "description": "Curies of InformationContentEntity objects given as evidence",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "gene_identifier": {
+                    "description": "Identifier (curie/primary_external_id/mod_internal_id) of the gene",
+                    "type": "string"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "pathway_identifier": {
+                    "description": "Identifier (curie/primary_external_id/mod_internal_id) of the pathway",
+                    "type": "string"
+                },
+                "relation_name": {
+                    "description": "Name of VocabularyTerm representing relation of an Association",
+                    "type": "string"
+                },
+                "updated_by_curie": {
+                    "description": "Curie of the Person object representing the individual that updated the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "gene_identifier",
+                "relation_name",
+                "pathway_identifier",
+                "internal"
+            ],
+            "title": "GenePathwayAssociationDTO",
             "type": "object"
         },
         "GenePhenotypeAnnotation": {
@@ -29863,6 +29960,15 @@
                         "null"
                     ]
                 },
+                "gene_pathway_association_ingest_set": {
+                    "items": {
+                        "$ref": "#/$defs/GenePathwayAssociationDTO"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "genome_assembly_ingest_set": {
                     "items": {
                         "$ref": "#/$defs/GenomeAssemblyDTO"
@@ -29897,6 +30003,15 @@
                 "ontology_closure_ingest_set": {
                     "items": {
                         "$ref": "#/$defs/OntologyTermClosure"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "pathway_ingest_set": {
+                    "items": {
+                        "$ref": "#/$defs/PathwayDTO"
                     },
                     "type": [
                         "array",
@@ -32845,7 +32960,8 @@
                 "WBBT",
                 "EMAPA",
                 "GO",
-                "SO"
+                "SO",
+                "PW"
             ],
             "title": "OntologyBulkLoadTypeEnum",
             "type": "string"
@@ -33933,12 +34049,22 @@
         },
         "Pathway": {
             "additionalProperties": false,
-            "description": "",
+            "description": "A series of molecular interactions and reactions occurring within a cell or organism that brings about a particular biological outcome.",
             "properties": {
                 "created_by": {
                     "description": "The individual that created the entity.",
                     "type": [
                         "string",
+                        "null"
+                    ]
+                },
+                "cross_references": {
+                    "description": "Holds between an object and its CrossReferences.",
+                    "items": {
+                        "$ref": "#/$defs/CrossReference"
+                    },
+                    "type": [
+                        "array",
                         "null"
                     ]
                 },
@@ -33996,6 +34122,20 @@
                         "null"
                     ]
                 },
+                "full_name": {
+                    "description": "The full name of the entity",
+                    "type": "string"
+                },
+                "gene_pathway_associations": {
+                    "description": "Gene participants in this pathway, with supporting evidence/references.",
+                    "items": {
+                        "$ref": "#/$defs/GenePathwayAssociation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "internal": {
                     "description": "Classifies the entity as private (for internal use) or not (for public use).",
                     "type": "boolean"
@@ -34014,6 +34154,27 @@
                         "null"
                     ]
                 },
+                "parent_sets": {
+                    "description": "Parent set(s) of which this set is a subset.",
+                    "items": {
+                        "$ref": "#/$defs/Pathway"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "pathway_image_filename": {
+                    "description": "Filename of an image file depicting the pathway.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "pathway_type": {
+                    "description": "The type of biological process that the pathway represents, given as a top-level term from the Pathway Ontology (PW).",
+                    "type": "string"
+                },
                 "primary_external_id": {
                     "description": "The primary external (non-Alliance) database identifier/curie for the object. Note that this may be an external (non-Alliance member) identifier for an object, like a UniProt ID for a protein, and may act as the MOD's/Alliance member's primary key for the entity.",
                     "type": [
@@ -34031,6 +34192,79 @@
                         "null"
                     ]
                 },
+                "related_sets": {
+                    "description": "Other related sets.",
+                    "items": {
+                        "$ref": "#/$defs/BiologicalEntitySet"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_bp_terms": {
+                    "description": "Key Gene Ontology Biological Process terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_cc_terms": {
+                    "description": "Key Gene Ontology Cellular Component terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_mf_terms": {
+                    "description": "Key Gene Ontology Molecular Function terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_synonyms": {
+                    "description": "Synonyms for the biological entity set.",
+                    "items": {
+                        "$ref": "#/$defs/BiologicalEntitySetSynonymSlotAnnotation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "symbol": {
+                    "description": "The free text symbol (human-readable) for an entity or record",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "taxon": {
+                    "description": "This slot is optional - it should not be used if multiple taxa are represented in the set.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "updated_by": {
                     "description": "The individual that last modified the entity.",
                     "type": [
@@ -34040,10 +34274,217 @@
                 }
             },
             "required": [
+                "pathway_type",
+                "full_name",
                 "data_provider",
                 "internal"
             ],
             "title": "Pathway",
+            "type": "object"
+        },
+        "PathwayDTO": {
+            "additionalProperties": false,
+            "description": "Ingest class for pathways (series of molecular interactions and reactions occurring within a cell or organism that bring about a particular biological outcome).",
+            "properties": {
+                "created_by_curie": {
+                    "description": "Curie of the Person object representing the individual that created the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "cross_reference_dtos": {
+                    "items": {
+                        "$ref": "#/$defs/CrossReferenceDTO"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "data_provider_dto": {
+                    "$ref": "#/$defs/DataProviderDTO",
+                    "description": "Ingest object representing the organization (e.g. MOD) from which the data was sourced and a CrossReference to that organisation's site"
+                },
+                "date_created": {
+                    "description": "The date on which an entity was created. This can be applied to nodes or edges.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_updated": {
+                    "description": "Date on which an entity was last modified.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_created": {
+                    "description": "The date on which an entity was created in the Alliance database.  This is distinct from date_created, which represents the date when the entity was originally created (i.e. at the MOD for imported data).",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "db_date_updated": {
+                    "description": "Date on which an entity was last modified in the Alliance database.  This is distinct from date_updated, which represents the date when the entity was last modified and may predate import into the Alliance database.",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "full_name": {
+                    "description": "The full name of the entity",
+                    "type": "string"
+                },
+                "internal": {
+                    "description": "Classifies the entity as private (for internal use) or not (for public use).",
+                    "type": "boolean"
+                },
+                "mod_internal_id": {
+                    "description": "The model organism database (MOD) internal identifier for the object",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "note_dtos": {
+                    "items": {
+                        "$ref": "#/$defs/NoteDTO"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "obsolete": {
+                    "description": "Entity is no longer current.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "parent_set_identifiers": {
+                    "description": "Identifiers (curie/primary_external_id/mod_internal_id) of parent set(s) of which this set is a subset.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "pathway_image_filename": {
+                    "description": "Filename of an image file depicting the pathway.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "pathway_type_curie": {
+                    "description": "CURIE of the top-level Pathway Ontology (PW) term representing the type of biological process that the pathway represents - one of PW:0000002 (classic metabolic pathway), PW:0000003 (signaling pathway), PW:0000004 (regulatory pathway), PW:0000013 (disease pathway), or PW:0000754 (drug pathway).",
+                    "type": "string"
+                },
+                "primary_external_id": {
+                    "description": "The primary external (non-Alliance) database identifier/curie for the object. Note that this may be an external (non-Alliance member) identifier for an object, like a UniProt ID for a protein, and may act as the MOD's/Alliance member's primary key for the entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "related_set_identifiers": {
+                    "description": "Identifiers (curie/primary_external_id/mod_internal_id) of other related sets.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "secondary_identifiers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_bp_term_curies": {
+                    "description": "CURIEs of key Gene Ontology Biological Process terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_cc_term_curies": {
+                    "description": "CURIEs of key Gene Ontology Cellular Component terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_go_mf_term_curies": {
+                    "description": "CURIEs of key Gene Ontology Molecular Function terms associated with this set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "set_synonym_dtos": {
+                    "description": "Synonyms for the biological entity set.",
+                    "items": {
+                        "$ref": "#/$defs/NameSlotAnnotationDTO"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "symbol": {
+                    "description": "The free text symbol (human-readable) for an entity or record",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "taxon_curie": {
+                    "description": "This slot is optional - it should not be used if multiple taxa are represented in the set.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "updated_by_curie": {
+                    "description": "Curie of the Person object representing the individual that updated the entity",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "pathway_type_curie",
+                "full_name",
+                "data_provider_dto",
+                "internal"
+            ],
+            "title": "PathwayDTO",
             "type": "object"
         },
         "Person": {
@@ -46148,6 +46589,15 @@
                 "null"
             ]
         },
+        "gene_pathway_association_ingest_set": {
+            "items": {
+                "$ref": "#/$defs/GenePathwayAssociationDTO"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
         "genome_assembly_ingest_set": {
             "items": {
                 "$ref": "#/$defs/GenomeAssemblyDTO"
@@ -46182,6 +46632,15 @@
         "ontology_closure_ingest_set": {
             "items": {
                 "$ref": "#/$defs/OntologyTermClosure"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "pathway_ingest_set": {
+            "items": {
+                "$ref": "#/$defs/PathwayDTO"
             },
             "type": [
                 "array",

--- a/model/schema/biologicalEntitySet.yaml
+++ b/model/schema/biologicalEntitySet.yaml
@@ -174,7 +174,7 @@ classes:
       organism that brings about a particular biological outcome.
     is_a: BiologicalEntitySet
     notes: >-
-      Each pathway is expected to carry exactly one related_note of type 'summary',
+      Each pathway is expected to carry exactly one related_notes entry of type 'summary',
       giving a curator-written textual description of the pathway. This cannot be
       expressed in the schema, as LinkML cannot require a note of a particular type,
       and so is enforced at load.
@@ -202,9 +202,15 @@ classes:
       - KEGG.PATHWAY
 
   ProteinComplex:
-    is_a: SubmittedObject
+    description: >-
+      A set of proteins that assemble into a stable complex to carry out a
+      biological function.
+    is_a: BiologicalEntitySet
     slots:
       - proteins
+    slot_usage:
+      parent_sets:
+        range: ProteinComplex
 
 
   GenePathwayAssociation:

--- a/model/schema/biologicalEntitySet.yaml
+++ b/model/schema/biologicalEntitySet.yaml
@@ -49,6 +49,63 @@ classes:
 # Types of BiologicalEntitySets
 # Attributes shared/specific to each type of BiologicalEntitySets.
 
+  BiologicalEntitySet:
+    description: >-
+      A named group of biological entities assembled because its members share a
+      biological property, function, or context.
+    is_a: SubmittedObject
+    abstract: true
+    notes: >-
+      Deliberately parented on SubmittedObject rather than BiologicalEntity, as
+      BiologicalEntity requires a single taxon and a set may span multiple taxa.
+    slots:
+      - taxon
+      - full_name
+      - symbol
+      - set_synonyms
+      - set_go_mf_terms
+      - set_go_bp_terms
+      - set_go_cc_terms
+      - parent_sets
+      - related_sets
+      - cross_references
+      - secondary_identifiers
+    slot_usage:
+      taxon:
+        description: >-
+          This slot is optional - it should not be used if multiple taxa are
+          represented in the set.
+        required: false
+      full_name:
+        required: true
+
+  BiologicalEntitySetDTO:
+    description: >-
+      Ingest class for named groups of biological entities assembled because their
+      members share a biological property, function, or context.
+    is_a: SubmittedObjectDTO
+    abstract: true
+    slots:
+      - taxon_curie
+      - full_name
+      - symbol
+      - set_synonym_dtos
+      - set_go_mf_term_curies
+      - set_go_bp_term_curies
+      - set_go_cc_term_curies
+      - parent_set_identifiers
+      - related_set_identifiers
+      - cross_reference_dtos
+      - secondary_identifiers
+    slot_usage:
+      taxon_curie:
+        description: >-
+          This slot is optional - it should not be used if multiple taxa are
+          represented in the set.
+        required: false
+      full_name:
+        required: true
+
   GeneCluster:
     description: >-
       A gene cluster is a set of genes which have a biological significance, and
@@ -104,33 +161,30 @@ classes:
   FunctionalGeneSet:
     description: >-
       Families and groups of genes related by sequence and/or function.
-    is_a: SubmittedObject
+    is_a: BiologicalEntitySet
     slots:
-      - taxon
-      - full_name
-      - symbol
-      - set_synonyms
-      - set_go_mf_terms
-      - set_go_bp_terms
-      - set_go_cc_terms
-      - parent_sets
-      - related_sets
-      - cross_references
-      - secondary_identifiers
       - gene_functional_gene_set_associations
     slot_usage:
-      taxon:
-        description: >-
-          This slot is optional - it should not be used if multiple taxa are
-          represented in the set.
-        required: false
-      full_name:
-        required: true
-      symbol:
-        required: true
+      parent_sets:
+        range: FunctionalGeneSet
 
   Pathway:
-    is_a: SubmittedObject
+    description: >-
+      A series of molecular interactions and reactions occurring within a cell or
+      organism that brings about a particular biological outcome.
+    is_a: BiologicalEntitySet
+    notes: >-
+      Each pathway is expected to carry exactly one related_note of type 'summary',
+      giving a curator-written textual description of the pathway. This cannot be
+      expressed in the schema, as LinkML cannot require a note of a particular type,
+      and so is enforced at load.
+    slots:
+      - pathway_type
+      - pathway_image_filename
+      - gene_pathway_associations
+    slot_usage:
+      parent_sets:
+        range: Pathway
     exact_mappings:
       - biolink:Pathway
       - PW:0000001
@@ -154,6 +208,9 @@ classes:
 
 
   GenePathwayAssociation:
+    description: >-
+      Association between a gene and a pathway, with supporting references that
+      demonstrate or state the gene's participation in the pathway.
     is_a: EvidenceAssociation
     slots:
       - gene_association_subject
@@ -163,7 +220,9 @@ classes:
         required: true
     slot_usage:
       relation:
-        subproperty_of: has_participant
+        subproperty_of: participates_in
+        notes: >-
+          CV 'Gene Pathway Association Relation' including - participates_in
 
   GeneFunctionalGeneSetAssociation:
     description: >-
@@ -179,44 +238,50 @@ classes:
     slot_usage:
       relation:
         subproperty_of: is_member_of
+        notes: >-
+          CV 'Gene Functional Gene Set Association Relation' including - is_member_of
 
-  FunctionalGeneSetSynonymSlotAnnotation:
+  BiologicalEntitySetSynonymSlotAnnotation:
     is_a: NameSlotAnnotation
     description: >-
-      All aliases (non-preferred names) for the functional gene set. Acceptable synonym
+      All aliases (non-preferred names) for the biological entity set. Acceptable synonym
       types are full_name, nomenclature_symbol, and unspecified
     slots:
-      - single_functional_gene_set
+      - single_biological_entity_set
     slot_usage:
-      single_functional_gene_set:
+      single_biological_entity_set:
         required: true
 
   FunctionalGeneSetDTO:
-    is_a: SubmittedObjectDTO
+    is_a: BiologicalEntitySetDTO
     description: >-
       Ingest class for functional gene sets (families and groups of genes
       related by sequence and/or function).
+
+  PathwayDTO:
+    is_a: BiologicalEntitySetDTO
+    description: >-
+      Ingest class for pathways (series of molecular interactions and reactions
+      occurring within a cell or organism that bring about a particular
+      biological outcome).
     slots:
-      - taxon_curie
-      - full_name
-      - symbol
-      - set_synonym_dtos
-      - set_go_mf_term_curies
-      - set_go_bp_term_curies
-      - set_go_cc_term_curies
-      - parent_set_identifiers
-      - related_set_identifiers
-      - cross_reference_dtos
-      - secondary_identifiers
-    slot_usage:
-      taxon_curie:
+      - pathway_type_curie
+      - pathway_image_filename
+
+  GenePathwayAssociationDTO:
+    description: >-
+      Ingest class for association between a gene and a pathway, with supporting
+      references that demonstrate or state the gene's participation in the
+      pathway.
+    is_a: EvidenceAssociationDTO
+    slots:
+      - gene_identifier
+      - relation_name
+    attributes:
+      pathway_identifier:
         description: >-
-          This slot is optional - it should not be used if multiple taxa are
-          represented in the set.
-        required: false
-      full_name:
-        required: true
-      symbol:
+          Identifier (curie/primary_external_id/mod_internal_id) of the pathway
+        range: string
         required: true
 
   GeneFunctionalGeneSetAssociationDTO:
@@ -261,6 +326,14 @@ slots:
     exact_mappings:
       - RO:0000057
 
+  participates_in:
+    description: >-
+      Indicates participation of a gene in a pathway. Inverse of has_participant;
+      used because the subject of a GenePathwayAssociation is the gene, not the
+      pathway.
+    exact_mappings:
+      - RO:0000056
+
   has_input:
     is_a: has_participant
 
@@ -296,43 +369,91 @@ slots:
 
   set_go_mf_terms:
     description: >-
-      Key Gene Ontology Molecular Function terms associated with this functional gene set.
+      Key Gene Ontology Molecular Function terms associated with this set.
     range: GOTerm
     multivalued: true
 
   set_go_bp_terms:
     description: >-
-      Key Gene Ontology Biological Process terms associated with this functional gene set.
+      Key Gene Ontology Biological Process terms associated with this set.
     range: GOTerm
     multivalued: true
 
   set_go_cc_terms:
     description: >-
-      Key Gene Ontology Cellular Component terms associated with this functional gene set.
+      Key Gene Ontology Cellular Component terms associated with this set.
     range: GOTerm
     multivalued: true
 
   set_synonyms:
     description: >-
-      Synonyms for the functional gene set.
-    domain: FunctionalGeneSet
-    range: FunctionalGeneSetSynonymSlotAnnotation
+      Synonyms for the biological entity set.
+    domain: BiologicalEntitySet
+    range: BiologicalEntitySetSynonymSlotAnnotation
     multivalued: true
 
-  single_functional_gene_set:
-    range: FunctionalGeneSet
+  single_biological_entity_set:
+    range: BiologicalEntitySet
     multivalued: false
 
   parent_sets:
     description: >-
-      Parent functional gene set(s) of which this set is a subset.
-    range: FunctionalGeneSet
+      Parent set(s) of which this set is a subset.
+    range: BiologicalEntitySet
     multivalued: true
 
   related_sets:
     description: >-
-      Other related functional gene sets.
-    range: FunctionalGeneSet
+      Other related sets.
+    range: BiologicalEntitySet
+    multivalued: true
+
+  pathway_type:
+    description: >-
+      The type of biological process that the pathway represents, given as a
+      top-level term from the Pathway Ontology (PW).
+    domain: Pathway
+    range: PWTerm
+    required: true
+    multivalued: false
+    notes: >-
+      Expected to be one of the five top-level PW terms - classic metabolic pathway
+      (PW:0000002), signaling pathway (PW:0000003), regulatory pathway (PW:0000004),
+      disease pathway (PW:0000013), or drug pathway (PW:0000754). PW is the canonical
+      Alliance representation of pathway type; MOD-native classifications of the same
+      concept (e.g. the FlyBase FBcv pathway group terms) are deliberately not captured.
+
+  pathway_type_curie:
+    description: >-
+      CURIE of the top-level Pathway Ontology (PW) term representing the type of
+      biological process that the pathway represents - one of PW:0000002 (classic
+      metabolic pathway), PW:0000003 (signaling pathway), PW:0000004 (regulatory
+      pathway), PW:0000013 (disease pathway), or PW:0000754 (drug pathway).
+    domain: PathwayDTO
+    range: string
+    required: true
+    multivalued: false
+
+  pathway_image_filename:
+    description: >-
+      Filename of an image file depicting the pathway.
+    range: string
+    required: false
+    multivalued: false
+    notes: >-
+      INTERIM - this slot records only a bare filename, with no accompanying
+      definition of where the file is stored or how a consumer resolves the name
+      to a retrievable image. The Alliance has no general mechanism for
+      submitting or hosting image files - the File class in image.yaml is a
+      placeholder with no slots, and there are no Image/Figure/File ingest
+      classes. To be revisited with the image working group, at which point this
+      slot should be replaced by a proper reference to an Image entity.
+
+  gene_pathway_associations:
+    description: >-
+      Gene participants in this pathway, with supporting evidence/references.
+    domain: Pathway
+    range: GenePathwayAssociation
     multivalued: true
 
   gene_functional_gene_set_associations:
@@ -350,8 +471,8 @@ slots:
 
   set_synonym_dtos:
     description: >-
-      Synonyms for the functional gene set.
-    domain: FunctionalGeneSetDTO
+      Synonyms for the biological entity set.
+    domain: BiologicalEntitySetDTO
     range: NameSlotAnnotationDTO
     multivalued: true
     inlined: true
@@ -360,35 +481,35 @@ slots:
   set_go_mf_term_curies:
     description: >-
       CURIEs of key Gene Ontology Molecular Function terms associated with
-      this functional gene set.
+      this set.
     range: string
     multivalued: true
 
   set_go_bp_term_curies:
     description: >-
       CURIEs of key Gene Ontology Biological Process terms associated with
-      this functional gene set.
+      this set.
     range: string
     multivalued: true
 
   set_go_cc_term_curies:
     description: >-
       CURIEs of key Gene Ontology Cellular Component terms associated with
-      this functional gene set.
+      this set.
     range: string
     multivalued: true
 
   parent_set_identifiers:
     description: >-
       Identifiers (curie/primary_external_id/mod_internal_id) of parent
-      functional gene set(s) of which this set is a subset.
+      set(s) of which this set is a subset.
     range: string
     multivalued: true
 
   related_set_identifiers:
     description: >-
       Identifiers (curie/primary_external_id/mod_internal_id) of other
-      related functional gene sets.
+      related sets.
     range: string
     multivalued: true
 

--- a/model/schema/bulkload.yaml
+++ b/model/schema/bulkload.yaml
@@ -264,6 +264,7 @@ enums:
       EMAPA:
       GO:
       SO:
+      PW:
 
   backend_bulk_data_type_enum:
     permissible_values:

--- a/model/schema/ingest.yaml
+++ b/model/schema/ingest.yaml
@@ -429,6 +429,20 @@ slots:
     mixins:
       - object_set
 
+  pathway_ingest_set:
+    domain: Ingest
+    range: PathwayDTO
+    multivalued: true
+    mixins:
+      - object_set
+
+  gene_pathway_association_ingest_set:
+    domain: Ingest
+    range: GenePathwayAssociationDTO
+    multivalued: true
+    mixins:
+      - object_set
+
   object_set:
     mixin: true
     domain: Ingest
@@ -497,3 +511,5 @@ classes:
       - high_throughput_expression_dataset_sample_annotation_ingest_set
       - functional_gene_set_ingest_set
       - gene_functional_gene_set_association_ingest_set
+      - pathway_ingest_set
+      - gene_pathway_association_ingest_set

--- a/test/data/functional_gene_set_alp_test.json
+++ b/test/data/functional_gene_set_alp_test.json
@@ -27,7 +27,7 @@
   ],
   "set_synonyms": [
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000960",
         "full_name": "ALKALINE PHOSPHATASES",
         "symbol": "ALP",
@@ -46,7 +46,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000960",
         "full_name": "ALKALINE PHOSPHATASES",
         "symbol": "ALP",
@@ -65,7 +65,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000960",
         "full_name": "ALKALINE PHOSPHATASES",
         "symbol": "ALP",

--- a/test/data/functional_gene_set_arp_test.json
+++ b/test/data/functional_gene_set_arp_test.json
@@ -37,7 +37,7 @@
   ],
   "set_synonyms": [
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000113",
         "full_name": "ACTIN-RELATED PROTEINS",
         "symbol": "ARP",
@@ -56,7 +56,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000113",
         "full_name": "ACTIN-RELATED PROTEINS",
         "symbol": "ARP",
@@ -75,7 +75,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000113",
         "full_name": "ACTIN-RELATED PROTEINS",
         "symbol": "ARP",

--- a/test/data/functional_gene_set_wnt_test.json
+++ b/test/data/functional_gene_set_wnt_test.json
@@ -31,7 +31,7 @@
   ],
   "set_synonyms": [
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000162",
         "full_name": "WNTs",
         "symbol": "WNT",
@@ -50,7 +50,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000162",
         "full_name": "WNTs",
         "symbol": "WNT",
@@ -69,7 +69,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000162",
         "full_name": "WNTs",
         "symbol": "WNT",
@@ -88,7 +88,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000162",
         "full_name": "WNTs",
         "symbol": "WNT",
@@ -107,7 +107,7 @@
       "internal": false
     },
     {
-      "single_functional_gene_set": {
+      "single_biological_entity_set": {
         "curie": "FB:FBgg0000162",
         "full_name": "WNTs",
         "symbol": "WNT",

--- a/test/data/pathway_ingest_test.json
+++ b/test/data/pathway_ingest_test.json
@@ -1,0 +1,364 @@
+{
+  "linkml_version": "2.3.0",
+  "pathway_ingest_set": [
+    {
+      "primary_external_id": "FB:FBgg0000978",
+      "data_provider_dto": {
+        "source_organization_abbreviation": "FB",
+        "cross_reference_dto": {
+          "referenced_curie": "FB:FBgg0000978",
+          "prefix": "FB",
+          "page_area": "pathway",
+          "display_name": "FB:FBgg0000978",
+          "internal": false
+        },
+        "internal": false
+      },
+      "taxon_curie": "NCBITaxon:7227",
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator",
+      "internal": false,
+      "full_name": "HEDGEHOG SIGNALING PATHWAY",
+      "symbol": "HH-SMO",
+      "pathway_type_curie": "PW:0000003",
+      "pathway_image_filename": "FBgg0000978_pathway_thumb.svg",
+      "note_dtos": [
+        {
+          "free_text": "The hedgehog signaling pathway is initiated by hedgehog (hh) ligand binding to the extracellular domain of patched receptor (ptc), leading to the derepression of smoothened (smo) activity. Activation of the atypical GPCR smo results in the accumulation of the transcriptional activator form of cubitus interruptus (ci) and the derepression/activation of hh target genes. In the absence of hh, smo is repressed by ptc and ci is processed to a truncated repressor form. (Adapted from FBrf0220683 and FBrf0231236).",
+          "note_type_name": "summary",
+          "internal": false,
+          "evidence_curies": [
+            "FB:FBrf0225556"
+          ]
+        }
+      ],
+      "set_synonym_dtos": [
+        {
+          "name_type_name": "full_name",
+          "format_text": "Smoothened signaling pathway",
+          "display_text": "Smoothened signaling pathway",
+          "synonym_scope_name": "exact",
+          "internal": false,
+          "evidence_curies": [
+            "FB:FBrf0225556"
+          ]
+        }
+      ],
+      "related_set_identifiers": [
+        "FB:FBgg0001342"
+      ],
+      "cross_reference_dtos": [
+        {
+          "referenced_curie": "KEGG:dme04341",
+          "prefix": "KEGG",
+          "page_area": "default",
+          "display_name": "KEGG Hedgehog signaling pathway",
+          "internal": false
+        },
+        {
+          "referenced_curie": "REACT:R-DME-209392",
+          "prefix": "REACT",
+          "page_area": "default",
+          "display_name": "Reactome Hedgehog signaling",
+          "internal": false
+        },
+        {
+          "referenced_curie": "WIKIPATHWAYS:WP492",
+          "prefix": "WIKIPATHWAYS",
+          "page_area": "default",
+          "display_name": "WikiPathways Hedgehog signaling",
+          "internal": false
+        }
+      ]
+    },
+    {
+      "primary_external_id": "FB:FBgg0002043",
+      "data_provider_dto": {
+        "source_organization_abbreviation": "FB",
+        "cross_reference_dto": {
+          "referenced_curie": "FB:FBgg0002043",
+          "prefix": "FB",
+          "page_area": "pathway",
+          "display_name": "FB:FBgg0002043",
+          "internal": false
+        },
+        "internal": false
+      },
+      "taxon_curie": "NCBITaxon:7227",
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator",
+      "internal": false,
+      "full_name": "GLYCOLYSIS",
+      "symbol": "GLYCO",
+      "pathway_type_curie": "PW:0000002",
+      "pathway_image_filename": "FBgg0002043_pathway_thumb.svg",
+      "note_dtos": [
+        {
+          "free_text": "Glycolysis converts glucose into ATP and pyruvate in the cytosol. The overall reaction is glucose + 2 ADP + 2Pi + 2 NAD+ -> 2 pyruvate + 2 ATP + 2 NADH 2H+ + 2 H2O and involves 10 enzymatic steps. (Adapted from PMID:33941515 and FBrf0144936.)",
+          "note_type_name": "summary",
+          "internal": false,
+          "evidence_curies": [
+            "FB:FBrf0225556"
+          ]
+        }
+      ],
+      "set_synonym_dtos": [
+        {
+          "name_type_name": "full_name",
+          "format_text": "Canonical glycolysis",
+          "display_text": "Canonical glycolysis",
+          "synonym_scope_name": "exact",
+          "internal": false,
+          "evidence_curies": [
+            "FB:FBrf0225556"
+          ]
+        }
+      ],
+      "set_go_bp_term_curies": [
+        "GO:0061621"
+      ],
+      "set_go_cc_term_curies": [
+        "GO:0005829"
+      ],
+      "parent_set_identifiers": [
+        "FB:FBgg0002134"
+      ],
+      "cross_reference_dtos": [
+        {
+          "referenced_curie": "FlyCyc:DMEL:ANAGLYCOLYSIS-PWY",
+          "prefix": "FlyCyc",
+          "page_area": "default",
+          "display_name": "FlyCyc glycolysis",
+          "internal": false
+        },
+        {
+          "referenced_curie": "go.model:65a1f4f800000617",
+          "prefix": "go.model",
+          "page_area": "default",
+          "display_name": "GO-CAM model of glycolysis",
+          "internal": false
+        },
+        {
+          "referenced_curie": "KEGG:dme00010",
+          "prefix": "KEGG",
+          "page_area": "default",
+          "display_name": "KEGG Glycolysis / Gluconeogenesis",
+          "internal": false
+        },
+        {
+          "referenced_curie": "REACT:R-DME-70171",
+          "prefix": "REACT",
+          "page_area": "default",
+          "display_name": "Reactome Glycolysis",
+          "internal": false
+        }
+      ]
+    }
+  ],
+  "gene_pathway_association_ingest_set": [
+    {
+      "gene_identifier": "FB:FBgn0003444",
+      "pathway_identifier": "FB:FBgg0000978",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0004644",
+      "pathway_identifier": "FB:FBgg0000978",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0040388",
+      "pathway_identifier": "FB:FBgg0000978",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0031872",
+      "pathway_identifier": "FB:FBgg0000978",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0001079",
+      "pathway_identifier": "FB:FBgg0000978",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0000064",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0000579",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0001091",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0001092",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0001186",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0001187",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0003071",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0014869",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0003074",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0250906",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0267385",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    },
+    {
+      "gene_identifier": "FB:FBgn0086355",
+      "pathway_identifier": "FB:FBgg0002043",
+      "relation_name": "participates_in",
+      "evidence_curies": [
+        "FB:FBrf0225556"
+      ],
+      "internal": false,
+      "obsolete": false,
+      "created_by_curie": "FB:FB_curator",
+      "updated_by_curie": "FB:FB_curator"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Introduces an abstract `BiologicalEntitySet` parent to hold the descriptive slots shared by `FunctionalGeneSet` and `Pathway`, and expands `Pathway` from a bare stub (mappings and `id_prefixes` only, no slots, no DTO, no ingest) into a fully submittable class.

Built against the agreed Pathway data class spec. Every field in that spec is accounted for, and the resulting model accommodates **three MODs with no MOD-specific slots**:

- **FlyBase** — FBgg pathway reports, the original driver
- **RGD** — via the Pathway Ontology, which is RGD-maintained
- **SGD** — biochemical pathways map onto `PW:0000002` (classic metabolic pathway); descriptions satisfy the expected summary note

## Pathway-specific additions

| Need | Resolution |
|---|---|
| Pathway type | `pathway_type`, **required**, `range: PWTerm` — one of the five top-level PW terms, verified against OLS |
| Pathway image | `pathway_image_filename`, optional — **interim**, see below |
| GO-CAM model ID | No new slot — submitted as a `cross_reference` with the `go.model` prefix |

`pathway_image_filename` records only a bare filename, with no definition of where files are stored or how a consumer resolves the name. This is deliberate and documented in the slot's `notes:`. The Alliance has no mechanism for submitting or hosting images — `File` in `image.yaml` is a placeholder with no slots, there are no Image/Figure/File DTOs or ingest sets, and none of those classes is implemented in the curation app. To be revisited with the image working group.

## Relation correction

`GenePathwayAssociation` used `subproperty_of: has_participant` (RO:0000057). The association's subject is the gene, so that read *"gene has_participant pathway"* — inverted with respect to the equivalent `is_member_of` on `GeneFunctionalGeneSetAssociation`. Now `participates_in` (RO:0000056).

This predates the PR and was harmless while `Pathway` had no DTO or ingest set. It matters now, because it becomes the relation DQMs are told to use.

## Note for reviewers: this changes FunctionalGeneSet's shipped contract

`FunctionalGeneSet` shipped in v2.17.0 (2026-06-04). Reparenting it changes that contract:

- `symbol` becomes **optional** (`full_name` stays required) — per the spec
- `FunctionalGeneSetSynonymSlotAnnotation` → `BiologicalEntitySetSynonymSlotAnnotation`
- `single_functional_gene_set` → `single_biological_entity_set`
- `parent_sets` is narrowed to the child class via `slot_usage`; `related_sets` stays ranged on `BiologicalEntitySet` so a pathway can relate to a protein complex, as curated at FlyBase

This is safe, but the reason isn't visible in the diff: **`FunctionalGeneSet` was never operationalised at any layer.** No Java entity, no REST endpoint (`/api/functionalgeneset` returns 404 where `/api/gene` returns 401), no loader, no data, and no relation vocabulary. There is nothing to migrate and no re-submission to ask of any MOD.

## Prerequisites before any load

Three items, none visible in the diff, all blocking:

1. Create CV `'Gene Pathway Association Relation'` with term `participates_in`
2. Create CV `'Gene Functional Gene Set Association Relation'` with term `is_member_of` — a pre-existing gap, not introduced here, which blocks `FunctionalGeneSet` loading too
3. Confirm **PW is actually loaded**. `PW` was missing from `ontology_bulk_load_type_enum` and is added here, but `PWTerm` was declared long before without ever being wired to the loader. `pathway_type` is required, so it hard-fails if the terms aren't populated.

## Testing

`test/data/pathway_ingest_test.json` is built from the spec's two worked examples — HEDGEHOG SIGNALING PATHWAY (`FBgg0000978`, signaling) and GLYCOLYSIS (`FBgg0002043`, metabolic) — using real FBgn/FBgg/FBrf identifiers. Between them they exercise `pathway_type`, `pathway_image_filename`, a GO-CAM cross-reference, `parent_sets`, `related_sets` pointing at a protein complex, key GO terms, synonym and note attribution, and 17 gene participation associations. Registered in `SCHEMA_TEST_EXAMPLES`.

Both `gen-json-schema` invocations build clean, and both the pathway and functional gene set ingest tests validate against the closed Ingest schema.

The three `functional_gene_set_*_test.json` files are updated for the slot rename. They are not registered in the Makefile, so were not being validated.

## Not addressed

- **Per-value reference attribution** on `pathway_type`, `set_go_*_terms`, `parent_sets` and `related_sets`. The spec marks these as needing attribution, but always to the same constant internal reference, so association classes to store it would carry no information. Synonyms, notes and gene membership already carry evidence and do so in the test data.
- **Requiring the summary note.** LinkML cannot require a note of a particular type within `related_notes`, so this is enforced at load and documented in `Pathway`'s `notes:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
